### PR TITLE
Implement folder-based template system

### DIFF
--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/Ultimate_Shop_Core.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/Ultimate_Shop_Core.java
@@ -18,6 +18,9 @@ public final class Ultimate_Shop_Core extends JavaPlugin {
     public void onEnable() {
         instance = this;
         // Plugin startup logic
+        saveDefaultConfig();
+        saveResource("templates/default/shop.yml", false);
+        saveResource("templates/default/food.yml", false);
         Lamp<BukkitCommandActor> lamp = BukkitLamp.builder(this).build();
         lamp.register(new ShopCommand());
 

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/datatypes/Range.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/datatypes/Range.java
@@ -40,20 +40,28 @@ public class Range {
     // ✅ Generic parser from YAML path (no hardcoding key/attr)
     public static List<Range> parseFromYaml(YamlConfiguration yml, String path) {
         Object value = yml.get(path);
+        return parseFromObject(value);
+    }
+
+    /**
+     * Parse slot ranges from an arbitrary object. Supported types are Integer,
+     * String (range syntax), or a List containing those types.
+     */
+    public static List<Range> parseFromObject(Object value) {
         List<Range> ranges = new ArrayList<>();
 
         if (value == null) return ranges;
 
-        if (value instanceof Integer) {
-            ranges.add(new Range((Integer) value));
-        } else if (value instanceof String) {
-            ranges.addAll(parseRangeString((String) value));
-        } else if (value instanceof List) {
-            for (Object item : (List<?>) value) {
-                if (item instanceof Integer) {
-                    ranges.add(new Range((Integer) item));
-                } else if (item instanceof String) {
-                    ranges.addAll(parseRangeString((String) item));
+        if (value instanceof Integer i) {
+            ranges.add(new Range(i));
+        } else if (value instanceof String s) {
+            ranges.addAll(parseRangeString(s));
+        } else if (value instanceof List<?> list) {
+            for (Object item : list) {
+                if (item instanceof Integer j) {
+                    ranges.add(new Range(j));
+                } else if (item instanceof String str) {
+                    ranges.addAll(parseRangeString(str));
                 }
             }
         }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopMenuListener.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopMenuListener.java
@@ -3,6 +3,7 @@ package com.hmmbo.ultimate_Shop_Core.shop.listeners;
 import com.hmmbo.ultimate_Shop_Core.datatypes.Custom_Inventory;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplate;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplateItemStack;
+import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -16,12 +17,32 @@ public class ShopMenuListener implements Listener {
 
         if (inv.getHolder() instanceof Custom_Inventory shopHolder) {
             ShopTemplate template = shopHolder.getTemplate();
-
-            event.getWhoClicked().sendMessage("This is a Shop GUI: " + template.getName());
-            event.getWhoClicked().sendMessage(ShopTemplateItemStack.extractType(
-                    event.getCurrentItem()).toString());
-
+            ShopTemplateItemStack.Type type = ShopTemplateItemStack.extractType(event.getCurrentItem());
             event.setCancelled(true);
+
+            if (type == null) return;
+
+            switch (type) {
+                case CATEGORY -> {
+                    String category = ShopTemplateItemStack.extractCategory(event.getCurrentItem());
+                    if (category == null) return;
+                    String folder = template.getName().split("/")[0];
+                    ShopTemplate cat = ShopTemplateManager.get().getTemplate(folder, category);
+                    if (cat != null) {
+                        event.getWhoClicked().openInventory(cat.createInventory());
+                    }
+                }
+                case BACK -> {
+                    String folder = template.getName().split("/")[0];
+                    ShopTemplate rootTemplate = ShopTemplateManager.get().getTemplate(folder, "shop");
+                    if (rootTemplate != null) {
+                        event.getWhoClicked().openInventory(rootTemplate.createInventory());
+                    }
+                }
+                case CLOSE -> event.getWhoClicked().closeInventory();
+                default -> {
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
@@ -60,8 +60,13 @@ public class ShopTemplateManager {
 
         YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
         int rows = config.getInt("rows", 4);
-        ShopTemplate.Type gui_type = ShopTemplate.Type.valueOf(config.getString("type", "GUI_SHOP"));
-        ShopTemplate template = new ShopTemplate(rows, key, gui_type);
+        String typeStr = config.getString("type", "GUI_SHOP");
+        ShopTemplate.Type guiType = ShopTemplate.Type.fromString(typeStr);
+        if (guiType == null) {
+            plugin.getLogger().warning("Unknown shop type '" + typeStr + "' in " + file.getName() + ", defaulting to GUI_SHOP");
+            guiType = ShopTemplate.Type.GUI_SHOP;
+        }
+        ShopTemplate template = new ShopTemplate(rows, key, guiType);
 
         if (config.isConfigurationSection("items")) {
             for (String keyItem : config.getConfigurationSection("items").getKeys(false)) {

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
@@ -18,6 +18,7 @@ public class ShopTemplateManager {
     private final JavaPlugin plugin;
     private final File templateFolder;
     public static final HashMap<String, ShopTemplate> cache = new HashMap<>();
+    private static ShopTemplateManager instance;
 
     public ShopTemplateManager(Ultimate_Shop_Core plugin) {
         this.plugin = plugin;
@@ -28,18 +29,30 @@ public class ShopTemplateManager {
             plugin.getLogger().info("Created templates folder: " + templateFolder.getPath());
         }
         loadAllTemplates();
+        instance = this;
     }
 
-    public ShopTemplate getTemplate(String fileName) {
+    public static ShopTemplateManager get() {
+        return instance;
+    }
+
+    public ShopTemplate getTemplate(String folderName, String fileName) {
         if (fileName.endsWith(".yml")) {
             fileName = fileName.substring(0, fileName.length() - 4);
         }
+        String key = folderName + "/" + fileName;
 
-        if (cache.containsKey(fileName)) {
-            return cache.get(fileName);
+        if (cache.containsKey(key)) {
+            return cache.get(key);
         }
 
-        File file = new File(templateFolder, fileName + ".yml");
+        File folder = new File(templateFolder, folderName);
+        if (!folder.exists()) {
+            plugin.getLogger().warning("Template folder not found: " + folder.getPath());
+            return null;
+        }
+
+        File file = new File(folder, fileName + ".yml");
         if (!file.exists()) {
             plugin.getLogger().warning("Template file not found: " + file.getPath());
             return null;
@@ -47,56 +60,65 @@ public class ShopTemplateManager {
 
         YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
         int rows = config.getInt("rows", 4);
-        ShopTemplate.Type gui_type = ShopTemplate.Type.valueOf(config.getString("type","GUI_SHOP"));
-        ShopTemplate template = new ShopTemplate(rows, fileName,gui_type);
+        ShopTemplate.Type gui_type = ShopTemplate.Type.valueOf(config.getString("type", "GUI_SHOP"));
+        ShopTemplate template = new ShopTemplate(rows, key, gui_type);
 
-        // Get section under "items"
-        for (String key : config.getConfigurationSection("items").getKeys(false)) {
-            String rootPath = "items." + key;
+        if (config.isConfigurationSection("items")) {
+            for (String keyItem : config.getConfigurationSection("items").getKeys(false)) {
+                String rootPath = "items." + keyItem;
 
-            // Parse type
-            String typeStr = config.getString(rootPath + ".type", "DECORATION");
-            ShopTemplateItemStack.Type type;
-            try {
-                type = ShopTemplateItemStack.Type.valueOf(typeStr.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                plugin.getLogger().warning("Invalid type in " + fileName + ": " + typeStr);
-                continue;
-            }
+                String typeStr = config.getString(rootPath + ".type", "DECORATION");
+                ShopTemplateItemStack.Type type;
+                try {
+                    type = ShopTemplateItemStack.Type.valueOf(typeStr.toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    plugin.getLogger().warning("Invalid type in " + fileName + ": " + typeStr);
+                    continue;
+                }
 
-            // Parse item
-            ItemStack itemStack;
-            try {
-                itemStack = config.getItemStack(rootPath + ".item");
-                if (itemStack == null) throw new IllegalArgumentException("ItemStack is null");
-            } catch (Exception e) {
-                plugin.getLogger().warning("Missing or invalid item in " + fileName + ": " + e.getMessage());
-                continue;
-            }
+                ItemStack itemStack;
+                try {
+                    itemStack = config.getItemStack(rootPath + ".item");
+                    if (itemStack == null) throw new IllegalArgumentException("ItemStack is null");
+                } catch (Exception e) {
+                    plugin.getLogger().warning("Missing or invalid item in " + fileName + ": " + e.getMessage());
+                    continue;
+                }
 
-            // Parse slot (supporting range syntax like 10-12, list of ranges/numbers)
-            List<Range> ranges = Range.parseFromYaml(config, rootPath + ".slot");
-            for (Range range : ranges) {
-                for (int i = range.getStart(); i <= range.getEnd(); i++) {
-                    template.addItem(new ShopTemplateItemStack(itemStack.clone(), type, i));
+                String category = null;
+                if (type == ShopTemplateItemStack.Type.CATEGORY) {
+                    category = config.getString(rootPath + ".category");
+                }
+
+                List<Range> ranges = Range.parseFromYaml(config, rootPath + ".slot");
+                for (Range range : ranges) {
+                    for (int i = range.getStart(); i <= range.getEnd(); i++) {
+                        template.addItem(new ShopTemplateItemStack(itemStack.clone(), type, i, category));
+                    }
                 }
             }
         }
 
-        cache.put(fileName, template);
+        cache.put(key, template);
         return template;
     }
 
 
 
     private void loadAllTemplates() {
-        File[] files = templateFolder.listFiles((dir, name) -> name.endsWith(".yml"));
-        if (files == null) return;
+        File[] folders = templateFolder.listFiles(File::isDirectory);
+        if (folders == null) return;
 
-        for (File file : files) {
-            String fileName = file.getName().replace(".yml", "");
-            if (!cache.containsKey(fileName)) {
-                getTemplate(fileName); // lazy-load with updated parser
+        for (File folder : folders) {
+            File[] files = folder.listFiles((dir, name) -> name.endsWith(".yml"));
+            if (files == null) continue;
+
+            for (File file : files) {
+                String yamlName = file.getName().replace(".yml", "");
+                String key = folder.getName() + "/" + yamlName;
+                if (!cache.containsKey(key)) {
+                    getTemplate(folder.getName(), yamlName);
+                }
             }
         }
 

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
@@ -60,13 +60,14 @@ public class ShopTemplateManager {
 
         YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
         int rows = config.getInt("rows", 4);
+        String inventoryName = config.getString("inventory_name", fileName);
         String typeStr = config.getString("type", "GUI_SHOP");
         ShopTemplate.Type guiType = ShopTemplate.Type.fromString(typeStr);
         if (guiType == null) {
             plugin.getLogger().warning("Unknown shop type '" + typeStr + "' in " + file.getName() + ", defaulting to GUI_SHOP");
             guiType = ShopTemplate.Type.GUI_SHOP;
         }
-        ShopTemplate template = new ShopTemplate(rows, key, guiType);
+        ShopTemplate template = new ShopTemplate(rows, key, inventoryName, guiType);
 
         if (config.isConfigurationSection("items")) {
             for (String keyItem : config.getConfigurationSection("items").getKeys(false)) {

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
@@ -72,12 +72,12 @@ public class ShopTemplateManager {
             for (String keyItem : config.getConfigurationSection("items").getKeys(false)) {
                 String rootPath = "items." + keyItem;
 
-                String typeStr = config.getString(rootPath + ".type", "DECORATION");
+                String itemTypeStr = config.getString(rootPath + ".type", "DECORATION");
                 ShopTemplateItemStack.Type type;
                 try {
-                    type = ShopTemplateItemStack.Type.valueOf(typeStr.toUpperCase());
+                    type = ShopTemplateItemStack.Type.valueOf(itemTypeStr.toUpperCase());
                 } catch (IllegalArgumentException e) {
-                    plugin.getLogger().warning("Invalid type in " + fileName + ": " + typeStr);
+                    plugin.getLogger().warning("Invalid type in " + fileName + ": " + itemTypeStr);
                     continue;
                 }
 

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
@@ -4,6 +4,7 @@ import com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core;
 import com.hmmbo.ultimate_Shop_Core.datatypes.Range;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplate;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplateItemStack;
+import com.hmmbo.ultimate_Shop_Core.utils.ItemUtil;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -76,7 +77,8 @@ public class ShopTemplateManager {
                     Object raw = itemList.get(idx);
                     if (!(raw instanceof Map<?, ?> map)) continue;
 
-                    String itemTypeStr = map.getOrDefault("type", "DECORATION").toString();
+                    Object typeObj = map.get("type");
+                    String itemTypeStr = typeObj == null ? "DECORATION" : typeObj.toString();
                     ShopTemplateItemStack.Type type;
                     try {
                         type = ShopTemplateItemStack.Type.valueOf(itemTypeStr.toUpperCase());
@@ -87,7 +89,7 @@ public class ShopTemplateManager {
 
                     ItemStack itemStack;
                     try {
-                        itemStack = (ItemStack) map.get("item");
+                        itemStack = ItemUtil.parseItem(map.get("item"));
                         if (itemStack == null) throw new IllegalArgumentException("ItemStack is null");
                     } catch (Exception e) {
                         plugin.getLogger().warning("Missing or invalid item in " + fileName + ": " + e.getMessage());
@@ -123,7 +125,7 @@ public class ShopTemplateManager {
 
                 ItemStack itemStack;
                 try {
-                    itemStack = config.getItemStack(rootPath + ".item");
+                    itemStack = ItemUtil.parseItem(config.get(rootPath + ".item"));
                     if (itemStack == null) throw new IllegalArgumentException("ItemStack is null");
                 } catch (Exception e) {
                     plugin.getLogger().warning("Missing or invalid item in " + fileName + ": " + e.getMessage());

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplate.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplate.java
@@ -12,6 +12,7 @@ public class ShopTemplate {
 
     private final int rows;
     private final String name;
+    private final String inventoryName;
     private final List<ShopTemplateItemStack> items;
     public enum Type {
         GUI_SHOP,
@@ -28,9 +29,10 @@ public class ShopTemplate {
 
     }
 
-    public ShopTemplate(int rows, String name,Type type ) {
+    public ShopTemplate(int rows, String name, String inventoryName, Type type) {
         this.rows = rows;
         this.name = name;
+        this.inventoryName = inventoryName;
         items = new ArrayList<>();
     }
 
@@ -44,7 +46,8 @@ public class ShopTemplate {
 
     public Inventory createInventory() {
         int size = rows * 9;
-        Inventory inventory = Bukkit.createInventory(new Custom_Inventory(this),size,name);
+        String title = inventoryName != null ? inventoryName : name;
+        Inventory inventory = Bukkit.createInventory(new Custom_Inventory(this), size, title);
         for (ShopTemplateItemStack templateItem : items) {
             int index = templateItem.getIndex();
             ItemStack stack = templateItem.getItemStack();
@@ -63,5 +66,9 @@ public class ShopTemplate {
 
     public String getName() {
         return name;
+    }
+
+    public String getInventoryName() {
+        return inventoryName;
     }
 }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplateItemStack.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplateItemStack.java
@@ -9,10 +9,12 @@ import org.bukkit.persistence.PersistentDataType;
 public class ShopTemplateItemStack {
 
     private static final NamespacedKey TYPE_KEY = new NamespacedKey("ultimate_shop_core", "template_type");
+    private static final NamespacedKey CATEGORY_KEY = new NamespacedKey("ultimate_shop_core", "template_category");
 
     private ItemStack itemStack;
     private Type type;
     private int index;
+    private String category;
 
     public enum Type {
         DECORATION,
@@ -20,7 +22,8 @@ public class ShopTemplateItemStack {
         PREV,
         CLOSE,
         BACK,
-        SHOP_ITEM;
+        SHOP_ITEM,
+        CATEGORY;
 
         public static Type fromString(String s) {
             try {
@@ -32,18 +35,26 @@ public class ShopTemplateItemStack {
     }
 
     public ShopTemplateItemStack(ItemStack itemStack, Type type, int index) {
+        this(itemStack, type, index, null);
+    }
+
+    public ShopTemplateItemStack(ItemStack itemStack, Type type, int index, String category) {
         this.itemStack = itemStack;
         this.type = type;
         this.index = index;
-        storeTypeInItem(itemStack, type);
+        this.category = category;
+        storeTypeAndCategory(itemStack, type, category);
     }
 
-    private void storeTypeInItem(ItemStack item, Type type) {
+    private void storeTypeAndCategory(ItemStack item, Type type, String category) {
         if (item == null || type == null) return;
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
 
         meta.getPersistentDataContainer().set(TYPE_KEY, PersistentDataType.STRING, type.name());
+        if (category != null) {
+            meta.getPersistentDataContainer().set(CATEGORY_KEY, PersistentDataType.STRING, category);
+        }
         item.setItemMeta(meta);
     }
 
@@ -59,13 +70,24 @@ public class ShopTemplateItemStack {
         return null;
     }
 
+    public static String extractCategory(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) return null;
+        ItemMeta meta = item.getItemMeta();
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+
+        if (container.has(CATEGORY_KEY, PersistentDataType.STRING)) {
+            return container.get(CATEGORY_KEY, PersistentDataType.STRING);
+        }
+        return null;
+    }
+
     public ItemStack getItemStack() {
         return itemStack;
     }
 
     public void setItemStack(ItemStack itemStack) {
         this.itemStack = itemStack;
-        storeTypeInItem(itemStack, this.type); // re-store type
+        storeTypeAndCategory(itemStack, this.type, this.category); // re-store data
     }
 
     public Type getType() {
@@ -74,7 +96,7 @@ public class ShopTemplateItemStack {
 
     public void setType(Type type) {
         this.type = type;
-        storeTypeInItem(this.itemStack, type); // re-store type
+        storeTypeAndCategory(this.itemStack, type, this.category); // re-store data
     }
 
     public int getIndex() {
@@ -83,5 +105,14 @@ public class ShopTemplateItemStack {
 
     public void setIndex(int index) {
         this.index = index;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+        storeTypeAndCategory(this.itemStack, this.type, category);
     }
 }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/ItemUtil.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/ItemUtil.java
@@ -1,0 +1,82 @@
+package com.hmmbo.ultimate_Shop_Core.utils;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility methods for building ItemStacks from simple map structures in YAML.
+ */
+public class ItemUtil {
+
+    /**
+     * Parses an item representation from configuration. Supports either a
+     * pre-serialized ItemStack or a map with keys like {@code type},
+     * {@code amount}, {@code display_name}, {@code lore} and {@code enchanted}.
+     *
+     * @param obj YAML object describing the item
+     * @return constructed ItemStack or {@code null} if the data is invalid
+     */
+    @SuppressWarnings("unchecked")
+    public static ItemStack parseItem(Object obj) {
+        if (obj instanceof ItemStack stack) {
+            return stack;
+        }
+
+        if (obj instanceof Map<?, ?> rawMap) {
+            Map<Object, Object> map = (Map<Object, Object>) rawMap;
+
+            Object typeObj = map.get("type");
+            if (typeObj == null) return null;
+
+            Material material = Material.matchMaterial(typeObj.toString());
+            if (material == null) return null;
+
+            int amount = 1;
+            if (map.containsKey("amount")) {
+                try {
+                    amount = Integer.parseInt(map.get("amount").toString());
+                } catch (NumberFormatException ignored) {
+                }
+            }
+
+            ItemStack stack = new ItemStack(material, amount);
+            ItemMeta meta = stack.getItemMeta();
+            if (meta != null) {
+                Object nameObj = map.get("display_name");
+                if (nameObj == null) nameObj = map.get("display-name");
+                if (nameObj != null) {
+                    meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', nameObj.toString()));
+                }
+
+                Object loreObj = map.get("lore");
+                if (loreObj instanceof List<?> loreList) {
+                    List<String> lore = new ArrayList<>();
+                    for (Object line : loreList) {
+                        lore.add(ChatColor.translateAlternateColorCodes('&', line.toString()));
+                    }
+                    meta.setLore(lore);
+                }
+
+                Object enchObj = map.get("enchanted");
+                if (enchObj != null && Boolean.parseBoolean(enchObj.toString())) {
+                    meta.addEnchant(Enchantment.DURABILITY, 1, true);
+                    meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                }
+
+                stack.setItemMeta(meta);
+            }
+            return stack;
+        }
+
+        return null;
+    }
+}
+

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/commands/ShopCommand.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/commands/ShopCommand.java
@@ -25,7 +25,7 @@ public class ShopCommand {
         }
     }
 
-    @Subcommand("admin change_template <name>")
+    @Command("shop admin change_template")
     @CommandPermission("usc.admin")
     public void changeTemplate(BukkitCommandActor sender, String name) {
         Ultimate_Shop_Core.instance.getConfig().set("shop_template", name);

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/commands/ShopCommand.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/commands/ShopCommand.java
@@ -51,7 +51,7 @@ public class ShopCommand {
     @Command("shop")
     public void onBasedCommand(BukkitCommandActor sender, String name) {
             Ultimate_Shop_Core.instance.getLogger().info(ShopTemplateManager.cache.toString());
-        sender.asPlayer().openInventory(ShopTemplateManager.cache.get(name).createInventory());
+        sender.asPlayer().openInventory(ShopTemplateManager.get().getTemplate(name, "shop").createInventory());
     }
 
         @Subcommand("buy")

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/commands/ShopCommand.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/commands/ShopCommand.java
@@ -3,67 +3,43 @@ package com.hmmbo.ultimate_Shop_Core.utils.commands;
 
 import com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core;
 import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
-import net.wesjd.anvilgui.AnvilGUI;
-import org.bukkit.Bukkit;
+import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplate;
 import org.bukkit.command.CommandSender;
 import revxrsal.commands.annotation.Command;
 import revxrsal.commands.annotation.Subcommand;
 import revxrsal.commands.bukkit.actor.BukkitCommandActor;
 import revxrsal.commands.bukkit.annotation.CommandPermission;
 
-import java.util.Collections;
-import java.util.List;
-
 @CommandPermission("")
 @Command("shop")
 public class ShopCommand {
 
-        @Command("shop")
-        public void onBaseCommand(BukkitCommandActor sender) {
-//
-         //   new AnvilGUI.Builder()
-//                    .onClick((slot, state) -> {
-//                        if (slot != AnvilGUI.Slot.OUTPUT) return Collections.emptyList();
-//
-//                        String input = state.getText();
-//
-//                        try {
-//                           state.getPlayer().sendMessage(input);
-//                        } catch (Exception e) {
-//                            state.getPlayer().sendMessage("Invalid format or error saving.");
-//                            return Collections.emptyList();
-//                        }
-//
-//                        return List.of(
-//                                AnvilGUI.ResponseAction.close()
-//                        );
-//                    })
-//                    .onClose(state -> sender.asPlayer().sendMessage("Closed Inventory"))
-//                    .text("5-10 or 8")
-//                    .title("Enter Xp Drop Range")
-//                    .plugin(Ultimate_Shop_Core.instance)
-//                    .open(sender.asPlayer());
-
-
-            sender.asPlayer().sendMessage("Welcome to the shop!");
-        }
-
     @Command("shop")
-    public void onBasedCommand(BukkitCommandActor sender, String name) {
-            Ultimate_Shop_Core.instance.getLogger().info(ShopTemplateManager.cache.toString());
-        sender.asPlayer().openInventory(ShopTemplateManager.get().getTemplate(name, "shop").createInventory());
+    public void onShopCommand(BukkitCommandActor sender) {
+        String template = Ultimate_Shop_Core.instance.getConfig().getString("shop_template", "default");
+        ShopTemplate shop = ShopTemplateManager.get().getTemplate(template, "shop");
+        if (shop != null) {
+            sender.asPlayer().openInventory(shop.createInventory());
+        } else {
+            sender.asPlayer().sendMessage("Shop template '" + template + "' not found.");
+        }
     }
 
-        @Subcommand("buy")
-        public void onBuyCommand(CommandSender sender) {
-            sender.sendMessage("You chose to buy something!");
-        }
+    @Subcommand("admin change_template <name>")
+    @CommandPermission("usc.admin")
+    public void changeTemplate(BukkitCommandActor sender, String name) {
+        Ultimate_Shop_Core.instance.getConfig().set("shop_template", name);
+        Ultimate_Shop_Core.instance.saveConfig();
+        sender.asPlayer().sendMessage("Shop template changed to " + name + ".");
+    }
 
-        @Subcommand("sell")
-        public void onSellCommand(CommandSender sender) {
-            sender.sendMessage("You chose to sell something!");
-        }
+    @Subcommand("buy")
+    public void onBuyCommand(CommandSender sender) {
+        sender.sendMessage("You chose to buy something!");
+    }
 
-
-
+    @Subcommand("sell")
+    public void onSellCommand(CommandSender sender) {
+        sender.sendMessage("You chose to sell something!");
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,1 @@
+# Default configuration

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,1 +1,2 @@
 # Default configuration
+shop_template: default

--- a/src/main/resources/templates/default/food.yml
+++ b/src/main/resources/templates/default/food.yml
@@ -5,15 +5,11 @@ items:
   - slot: 10-12
     type: SHOP_ITEM
     item:
-      ==: org.bukkit.inventory.ItemStack
-      v: 2868
       type: DIAMOND
-      meta:
-        ==: ItemMeta
-        meta-type: UNSPECIFIC
-        display-name: "§bBuy Diamond"
-        lore:
-          - "§7Precious gem"
+      display_name: "§bBuy Diamond"
+      enchanted: true
+      lore:
+        - "§7Precious gem"
   - slot: [19, "20-22", 25]
     type: DECORATION
     item:

--- a/src/main/resources/templates/default/food.yml
+++ b/src/main/resources/templates/default/food.yml
@@ -2,7 +2,6 @@ rows: 5
 type: "SHOP"
 items:
   - slot: 10-12
-    category: "Food"
     type: SHOP_ITEM
     item:
       ==: org.bukkit.inventory.ItemStack
@@ -14,7 +13,6 @@ items:
         display-name: "§bBuy Diamond"
         lore:
           - "§7Precious gem"
-
   - slot: [19, "20-22", 25]
     type: DECORATION
     item:
@@ -25,14 +23,13 @@ items:
         ==: ItemMeta
         meta-type: UNSPECIFIC
         display-name: "§r"
-
   - slot: 45
-    type: CLOSE
+    type: BACK
     item:
       ==: org.bukkit.inventory.ItemStack
       v: 2868
-      type: BARRIER
+      type: ARROW
       meta:
         ==: ItemMeta
         meta-type: UNSPECIFIC
-        display-name: "§cClose"
+        display-name: "§aBack"

--- a/src/main/resources/templates/default/food.yml
+++ b/src/main/resources/templates/default/food.yml
@@ -1,5 +1,6 @@
 rows: 5
 type: "SHOP"
+inventory_name: "Food"
 items:
   - slot: 10-12
     type: SHOP_ITEM

--- a/src/main/resources/templates/default/shop.yml
+++ b/src/main/resources/templates/default/shop.yml
@@ -6,30 +6,15 @@ items:
     category: "food"
     type: CATEGORY
     item:
-      ==: org.bukkit.inventory.ItemStack
-      v: 2868
       type: APPLE
-      meta:
-        ==: ItemMeta
-        meta-type: UNSPECIFIC
-        display-name: "§aFood Category"
+      display_name: "§aFood Category"
   - slot: [19, "20-22", 25]
     type: DECORATION
     item:
-      ==: org.bukkit.inventory.ItemStack
-      v: 2868
       type: GRAY_STAINED_GLASS_PANE
-      meta:
-        ==: ItemMeta
-        meta-type: UNSPECIFIC
-        display-name: "§r"
+      display_name: "§r"
   - slot: 45
     type: CLOSE
     item:
-      ==: org.bukkit.inventory.ItemStack
-      v: 2868
       type: BARRIER
-      meta:
-        ==: ItemMeta
-        meta-type: UNSPECIFIC
-        display-name: "§cClose"
+      display_name: "§cClose"

--- a/src/main/resources/templates/default/shop.yml
+++ b/src/main/resources/templates/default/shop.yml
@@ -1,5 +1,6 @@
 rows: 5
 type: "SHOP"
+inventory_name: "Shop"
 items:
   - slot: 10
     category: "food"

--- a/src/main/resources/templates/default/shop.yml
+++ b/src/main/resources/templates/default/shop.yml
@@ -1,0 +1,34 @@
+rows: 5
+type: "SHOP"
+items:
+  - slot: 10
+    category: "food"
+    type: CATEGORY
+    item:
+      ==: org.bukkit.inventory.ItemStack
+      v: 2868
+      type: APPLE
+      meta:
+        ==: ItemMeta
+        meta-type: UNSPECIFIC
+        display-name: "§aFood Category"
+  - slot: [19, "20-22", 25]
+    type: DECORATION
+    item:
+      ==: org.bukkit.inventory.ItemStack
+      v: 2868
+      type: GRAY_STAINED_GLASS_PANE
+      meta:
+        ==: ItemMeta
+        meta-type: UNSPECIFIC
+        display-name: "§r"
+  - slot: 45
+    type: CLOSE
+    item:
+      ==: org.bukkit.inventory.ItemStack
+      v: 2868
+      type: BARRIER
+      meta:
+        ==: ItemMeta
+        meta-type: UNSPECIFIC
+        display-name: "§cClose"


### PR DESCRIPTION
## Summary
- add CATEGORY type to hold category metadata in template items
- load templates from subfolders and cache them per template/category
- add navigation logic for CATEGORY, BACK and CLOSE items
- ship default config and example `default` template

## Testing
- `gradle build` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685693f38e848330bc4e660fe494eb85