### PR TITLE
Add Buy/Sell GUI with Vault support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'io.github.revxrsal:lamp.bukkit:4.0.0-rc.12'
     // Use latest AnvilGUI version compatible with MC 1.17+
     implementation 'net.wesjd:anvilgui:1.10.5-SNAPSHOT'
+    compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
 }
 
 def targetJavaVersion = 17

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ repositories {
     maven {
         url = "https://repo.codemc.io/repository/maven-snapshots/"
     }
+    maven {
+        url = "https://jitpack.io"
+    }
 }
 
 dependencies {

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/Ultimate_Shop_Core.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/Ultimate_Shop_Core.java
@@ -3,6 +3,7 @@ package com.hmmbo.ultimate_Shop_Core;
 import com.hmmbo.ultimate_Shop_Core.shop.listeners.ShopMenuListener;
 import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
 import com.hmmbo.ultimate_Shop_Core.utils.commands.ShopCommand;
+import com.hmmbo.ultimate_Shop_Core.economy.VaultUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -20,7 +21,9 @@ public final class Ultimate_Shop_Core extends JavaPlugin {
         // Plugin startup logic
         saveDefaultConfig();
         saveResource("templates/default/shop.yml", false);
-        saveResource("templates/default/food.yml", false);
+        saveResource("templates/default/buy_sell.yml", false);
+        saveResource("templates/default/categories/ores.yml", false);
+        VaultUtil.setup();
         Lamp<BukkitCommandActor> lamp = BukkitLamp.builder(this).build();
         lamp.register(new ShopCommand());
 

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/datatypes/Custom_Inventory.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/datatypes/Custom_Inventory.java
@@ -7,6 +7,7 @@ import org.bukkit.inventory.InventoryHolder;
 public class Custom_Inventory implements InventoryHolder {
 
     private final ShopTemplate template;
+    private Inventory inventory;
 
     public Custom_Inventory(ShopTemplate template) {
         this.template = template;
@@ -14,7 +15,10 @@ public class Custom_Inventory implements InventoryHolder {
 
     @Override
     public Inventory getInventory() {
-        return template.createInventory(); // optional
+        if (inventory == null) {
+            inventory = template.createInventory(this);
+        }
+        return inventory;
     }
 
     public ShopTemplate getTemplate() {

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/economy/VaultUtil.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/economy/VaultUtil.java
@@ -1,0 +1,24 @@
+package com.hmmbo.ultimate_Shop_Core.economy;
+
+import com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+public class VaultUtil {
+    private static Economy economy;
+
+    public static void setup() {
+        if (Bukkit.getPluginManager().getPlugin("Vault") == null) {
+            return;
+        }
+        RegisteredServiceProvider<Economy> rsp = Bukkit.getServicesManager().getRegistration(Economy.class);
+        if (rsp != null) {
+            economy = rsp.getProvider();
+        }
+    }
+
+    public static Economy getEconomy() {
+        return economy;
+    }
+}

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/datatypes/BuySellInventory.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/datatypes/BuySellInventory.java
@@ -1,0 +1,50 @@
+package com.hmmbo.ultimate_Shop_Core.shop.datatypes;
+
+import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplate;
+import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplateItemStack;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public class BuySellInventory implements InventoryHolder {
+
+    private final ShopTemplate template;
+    private final ShopTemplateItemStack shopItem;
+    private final ShopTemplate parentTemplate;
+    private int amount = 1;
+    private int displaySlot = -1;
+
+    public BuySellInventory(ShopTemplate template, ShopTemplateItemStack item, ShopTemplate parentTemplate) {
+        this.template = template;
+        this.shopItem = item;
+        this.parentTemplate = parentTemplate;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return template.createInventory(this);
+    }
+
+    public ShopTemplateItemStack getShopItem() {
+        return shopItem;
+    }
+
+    public ShopTemplate getParentTemplate() {
+        return parentTemplate;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public void setAmount(int amount) {
+        this.amount = Math.max(1, amount);
+    }
+
+    public int getDisplaySlot() {
+        return displaySlot;
+    }
+
+    public void setDisplaySlot(int displaySlot) {
+        this.displaySlot = displaySlot;
+    }
+}

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/datatypes/BuySellInventory.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/datatypes/BuySellInventory.java
@@ -12,6 +12,17 @@ public class BuySellInventory implements InventoryHolder {
     private final ShopTemplate parentTemplate;
     private int amount = 1;
     private int displaySlot = -1;
+    private boolean stackMode = false;
+    private boolean toggleMode = false;
+    private int buySlot = -1;
+    private int sellSlot = -1;
+    private int buyStackSlot = -1;
+    private int sellStackSlot = -1;
+    private int changeModeSlot = -1;
+    private ShopTemplateItemStack buyItem;
+    private ShopTemplateItemStack sellItem;
+    private ShopTemplateItemStack buyStackItem;
+    private ShopTemplateItemStack sellStackItem;
 
     public BuySellInventory(ShopTemplate template, ShopTemplateItemStack item, ShopTemplate parentTemplate) {
         this.template = template;
@@ -46,5 +57,93 @@ public class BuySellInventory implements InventoryHolder {
 
     public void setDisplaySlot(int displaySlot) {
         this.displaySlot = displaySlot;
+    }
+
+    public boolean isStackMode() {
+        return stackMode;
+    }
+
+    public void setStackMode(boolean stackMode) {
+        this.stackMode = stackMode;
+    }
+
+    public boolean hasToggleMode() {
+        return toggleMode;
+    }
+
+    public void setToggleMode(boolean toggleMode) {
+        this.toggleMode = toggleMode;
+    }
+
+    public int getBuySlot() {
+        return buySlot;
+    }
+
+    public void setBuySlot(int buySlot) {
+        this.buySlot = buySlot;
+    }
+
+    public int getSellSlot() {
+        return sellSlot;
+    }
+
+    public void setSellSlot(int sellSlot) {
+        this.sellSlot = sellSlot;
+    }
+
+    public int getBuyStackSlot() {
+        return buyStackSlot;
+    }
+
+    public void setBuyStackSlot(int buyStackSlot) {
+        this.buyStackSlot = buyStackSlot;
+    }
+
+    public int getSellStackSlot() {
+        return sellStackSlot;
+    }
+
+    public void setSellStackSlot(int sellStackSlot) {
+        this.sellStackSlot = sellStackSlot;
+    }
+
+    public int getChangeModeSlot() {
+        return changeModeSlot;
+    }
+
+    public void setChangeModeSlot(int changeModeSlot) {
+        this.changeModeSlot = changeModeSlot;
+    }
+
+    public ShopTemplateItemStack getBuyItem() {
+        return buyItem;
+    }
+
+    public void setBuyItem(ShopTemplateItemStack buyItem) {
+        this.buyItem = buyItem;
+    }
+
+    public ShopTemplateItemStack getSellItem() {
+        return sellItem;
+    }
+
+    public void setSellItem(ShopTemplateItemStack sellItem) {
+        this.sellItem = sellItem;
+    }
+
+    public ShopTemplateItemStack getBuyStackItem() {
+        return buyStackItem;
+    }
+
+    public void setBuyStackItem(ShopTemplateItemStack buyStackItem) {
+        this.buyStackItem = buyStackItem;
+    }
+
+    public ShopTemplateItemStack getSellStackItem() {
+        return sellStackItem;
+    }
+
+    public void setSellStackItem(ShopTemplateItemStack sellStackItem) {
+        this.sellStackItem = sellStackItem;
     }
 }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopMenuListener.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopMenuListener.java
@@ -14,19 +14,23 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
 
 public class ShopMenuListener implements Listener {
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
-        Inventory inv = event.getInventory();
+        InventoryView view = event.getView();
+        Inventory top = view.getTopInventory();
+        Inventory clicked = event.getClickedInventory();
 
-        if (inv.getHolder() instanceof Custom_Inventory shopHolder) {
+        if (top.getHolder() instanceof Custom_Inventory shopHolder) {
             ShopTemplate template = shopHolder.getTemplate();
             ShopTemplateItemStack.Type type = ShopTemplateItemStack.extractType(event.getCurrentItem());
             event.setCancelled(true);
-
+            
             if (type == null) return;
 
             switch (type) {
@@ -85,14 +89,14 @@ public class ShopMenuListener implements Listener {
                 default -> {
                 }
             }
-        } else if (inv.getHolder() instanceof BuySellInventory buySellHolder) {
+        } else if (top.getHolder() instanceof BuySellInventory buySellHolder) {
             event.setCancelled(true);
             ShopTemplateItemStack.Type type = ShopTemplateItemStack.extractType(event.getCurrentItem());
             String action = ShopTemplateItemStack.extractAction(event.getCurrentItem());
             if (type == null) return;
             Player player = (Player) event.getWhoClicked();
             switch (type) {
-                case ACTION -> handleAction(player, buySellHolder, action, inv);
+                case ACTION -> handleAction(player, buySellHolder, action, top);
                 case BACK -> player.openInventory(buySellHolder.getParentTemplate().createInventory());
                 case CLOSE -> player.closeInventory();
                 default -> {
@@ -199,5 +203,14 @@ public class ShopMenuListener implements Listener {
                 .title("Enter Amount")
                 .plugin(com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core.instance)
                 .open(player);
+    }
+
+    @EventHandler
+    public void onInventoryDrag(InventoryDragEvent event) {
+        InventoryView view = event.getView();
+        Inventory top = view.getTopInventory();
+        if (top.getHolder() instanceof Custom_Inventory || top.getHolder() instanceof BuySellInventory) {
+            event.setCancelled(true);
+        }
     }
 }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopMenuListener.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopMenuListener.java
@@ -4,6 +4,13 @@ import com.hmmbo.ultimate_Shop_Core.datatypes.Custom_Inventory;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplate;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplateItemStack;
 import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
+import com.hmmbo.ultimate_Shop_Core.shop.datatypes.BuySellInventory;
+import com.hmmbo.ultimate_Shop_Core.economy.VaultUtil;
+import net.milkbowl.vault.economy.Economy;
+import net.wesjd.anvilgui.AnvilGUI;
+import org.bukkit.ChatColor;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -32,6 +39,22 @@ public class ShopMenuListener implements Listener {
                         event.getWhoClicked().openInventory(cat.createInventory());
                     }
                 }
+                case SHOP_ITEM -> {
+                    String folder = template.getName().split("/")[0];
+                    ShopTemplate buySell = ShopTemplateManager.get().getTemplate(folder, "buy_sell");
+                    if (buySell != null) {
+                        BuySellInventory holder = new BuySellInventory(buySell, new ShopTemplateItemStack(event.getCurrentItem().clone(), ShopTemplateItemStack.Type.SHOP_ITEM, 0, null, null, ShopTemplateItemStack.extractBuyPrice(event.getCurrentItem()), ShopTemplateItemStack.extractSellPrice(event.getCurrentItem())), template);
+                        Inventory newInv = buySell.createInventory(holder, event.getCurrentItem().clone());
+                        for (ShopTemplateItemStack it : buySell.getItems()) {
+                            if (it.getType() == ShopTemplateItemStack.Type.SELECTED_ITEM) {
+                                holder.setDisplaySlot(it.getIndex());
+                                newInv.setItem(it.getIndex(), event.getCurrentItem().clone());
+                                break;
+                            }
+                        }
+                        event.getWhoClicked().openInventory(newInv);
+                    }
+                }
                 case BACK -> {
                     String folder = template.getName().split("/")[0];
                     ShopTemplate rootTemplate = ShopTemplateManager.get().getTemplate(folder, "shop");
@@ -43,6 +66,102 @@ public class ShopMenuListener implements Listener {
                 default -> {
                 }
             }
+        } else if (inv.getHolder() instanceof BuySellInventory buySellHolder) {
+            event.setCancelled(true);
+            ShopTemplateItemStack.Type type = ShopTemplateItemStack.extractType(event.getCurrentItem());
+            String action = ShopTemplateItemStack.extractAction(event.getCurrentItem());
+            if (type == null) return;
+            Player player = (Player) event.getWhoClicked();
+            switch (type) {
+                case ACTION -> handleAction(player, buySellHolder, action, inv);
+                case BACK -> player.openInventory(buySellHolder.getParentTemplate().createInventory());
+                case CLOSE -> player.closeInventory();
+                default -> {
+                }
+            }
         }
+    }
+
+    private void handleAction(Player player, BuySellInventory holder, String action, Inventory inv) {
+        if (action == null) return;
+        switch (action.toLowerCase()) {
+            case "add1" -> modifyAmount(holder, inv, 1);
+            case "add16" -> modifyAmount(holder, inv, 16);
+            case "add32" -> modifyAmount(holder, inv, 32);
+            case "add64" -> modifyAmount(holder, inv, 64);
+            case "buy_stack" -> processBuy(player, holder, 64);
+            case "sell_stack" -> processSell(player, holder, 64);
+            case "buy" -> processBuy(player, holder, holder.getAmount());
+            case "sell" -> processSell(player, holder, holder.getAmount());
+            case "input" -> openAnvil(player, holder, inv);
+            default -> {}
+        }
+    }
+
+    private void modifyAmount(BuySellInventory holder, Inventory inv, int add) {
+        holder.setAmount(holder.getAmount() + add);
+        updateDisplay(inv, holder);
+    }
+
+    private void updateDisplay(Inventory inv, BuySellInventory holder) {
+        if (holder.getDisplaySlot() < 0) return;
+        ItemStack stack = holder.getShopItem().getItemStack().clone();
+        int amt = Math.min(64, holder.getAmount());
+        stack.setAmount(amt);
+        inv.setItem(holder.getDisplaySlot(), stack);
+    }
+
+    private void processBuy(Player player, BuySellInventory holder, int amount) {
+        Economy econ = VaultUtil.getEconomy();
+        if (econ == null) return;
+        double total = holder.getShopItem().getBuyPrice() * amount;
+        if (!econ.has(player, total)) {
+            player.sendMessage(ChatColor.RED + "Not enough money");
+            return;
+        }
+        ItemStack item = holder.getShopItem().getItemStack().clone();
+        item.setAmount(amount);
+        if (!player.getInventory().addItem(item).isEmpty()) {
+            player.sendMessage(ChatColor.RED + "Not enough inventory space");
+            return;
+        }
+        econ.withdrawPlayer(player, total);
+        player.sendMessage(ChatColor.GREEN + "You bought " + amount + " " + item.getType().toString().toLowerCase() + " for $" + total);
+    }
+
+    private void processSell(Player player, BuySellInventory holder, int amount) {
+        Economy econ = VaultUtil.getEconomy();
+        if (econ == null) return;
+        ItemStack item = holder.getShopItem().getItemStack();
+        ItemStack remove = item.clone();
+        remove.setAmount(amount);
+        if (!player.getInventory().containsAtLeast(item, amount)) {
+            player.sendMessage(ChatColor.RED + "Not enough items");
+            return;
+        }
+        player.getInventory().removeItem(remove);
+        double total = holder.getShopItem().getSellPrice() * amount;
+        econ.depositPlayer(player, total);
+        player.sendMessage(ChatColor.GREEN + "You sold " + amount + " " + item.getType().toString().toLowerCase() + " for $" + total);
+    }
+
+    private void openAnvil(Player player, BuySellInventory holder, Inventory inv) {
+        new AnvilGUI.Builder()
+                .onClick((slot, state) -> {
+                    if (slot != AnvilGUI.Slot.OUTPUT) return java.util.Collections.emptyList();
+                    try {
+                        int val = Integer.parseInt(state.getText());
+                        holder.setAmount(val);
+                        updateDisplay(inv, holder);
+                    } catch (Exception e) {
+                        player.sendMessage(ChatColor.RED + "Invalid number");
+                    }
+                    return java.util.List.of(AnvilGUI.ResponseAction.close());
+                })
+                .onClose(state -> player.sendMessage("Closed Inventory"))
+                .text("5-10 or 8")
+                .title("Enter Amount")
+                .plugin(com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core.instance)
+                .open(player);
     }
 }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
@@ -101,11 +101,22 @@ public class ShopTemplateManager {
                         Object catObj = map.get("category");
                         if (catObj != null) category = catObj.toString();
                     }
+                    String action = null;
+                    if (type == ShopTemplateItemStack.Type.ACTION) {
+                        Object actObj = map.get("action");
+                        if (actObj != null) action = actObj.toString();
+                    }
+                    double buyPrice = 0;
+                    double sellPrice = 0;
+                    if (type == ShopTemplateItemStack.Type.SHOP_ITEM) {
+                        buyPrice = getDouble(map, "buy_price");
+                        sellPrice = getDouble(map, "sell_price");
+                    }
 
                     List<Range> ranges = Range.parseFromObject(map.get("slot"));
                     for (Range range : ranges) {
                         for (int i = range.getStart(); i <= range.getEnd(); i++) {
-                            template.addItem(new ShopTemplateItemStack(itemStack.clone(), type, i, category));
+                            template.addItem(new ShopTemplateItemStack(itemStack.clone(), type, i, category, action, buyPrice, sellPrice));
                         }
                     }
                 }
@@ -136,11 +147,21 @@ public class ShopTemplateManager {
                 if (type == ShopTemplateItemStack.Type.CATEGORY) {
                     category = config.getString(rootPath + ".category");
                 }
+                String action = null;
+                if (type == ShopTemplateItemStack.Type.ACTION) {
+                    action = config.getString(rootPath + ".action");
+                }
+                double buyPrice = 0;
+                double sellPrice = 0;
+                if (type == ShopTemplateItemStack.Type.SHOP_ITEM) {
+                    buyPrice = config.getDouble(rootPath + ".buy_price", 0);
+                    sellPrice = config.getDouble(rootPath + ".sell_price", 0);
+                }
 
                 List<Range> ranges = Range.parseFromYaml(config, rootPath + ".slot");
                 for (Range range : ranges) {
                     for (int i = range.getStart(); i <= range.getEnd(); i++) {
-                        template.addItem(new ShopTemplateItemStack(itemStack.clone(), type, i, category));
+                        template.addItem(new ShopTemplateItemStack(itemStack.clone(), type, i, category, action, buyPrice, sellPrice));
                     }
                 }
             }
@@ -148,6 +169,16 @@ public class ShopTemplateManager {
 
         cache.put(key, template);
         return template;
+    }
+
+    private double getDouble(Map<?, ?> map, String key) {
+        Object val = map.get(key);
+        if (val == null) return 0;
+        try {
+            return Double.parseDouble(val.toString());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
 

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplate.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplate.java
@@ -3,6 +3,7 @@ package com.hmmbo.ultimate_Shop_Core.shop.template;
 import com.hmmbo.ultimate_Shop_Core.datatypes.Custom_Inventory;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -45,12 +46,24 @@ public class ShopTemplate {
     }
 
     public Inventory createInventory() {
+        return createInventory(new Custom_Inventory(this), null);
+    }
+
+    public Inventory createInventory(InventoryHolder holder) {
+        return createInventory(holder, null);
+    }
+
+    public Inventory createInventory(InventoryHolder holder, ItemStack displayItem) {
         int size = rows * 9;
         String title = inventoryName != null ? inventoryName : name;
-        Inventory inventory = Bukkit.createInventory(new Custom_Inventory(this), size, title);
+        Inventory inventory = Bukkit.createInventory(holder, size, title);
         for (ShopTemplateItemStack templateItem : items) {
             int index = templateItem.getIndex();
             ItemStack stack = templateItem.getItemStack();
+
+            if (templateItem.getType() == ShopTemplateItemStack.Type.SELECTED_ITEM && displayItem != null) {
+                stack = displayItem;
+            }
 
             if (index >= 0 && index < size) {
                 inventory.setItem(index, stack);

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplate.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplate.java
@@ -46,7 +46,8 @@ public class ShopTemplate {
     }
 
     public Inventory createInventory() {
-        return createInventory(new Custom_Inventory(this), null);
+        Custom_Inventory holder = new Custom_Inventory(this);
+        return holder.getInventory();
     }
 
     public Inventory createInventory(InventoryHolder holder) {

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplateItemStack.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplateItemStack.java
@@ -10,11 +10,17 @@ public class ShopTemplateItemStack {
 
     private static final NamespacedKey TYPE_KEY = new NamespacedKey("ultimate_shop_core", "template_type");
     private static final NamespacedKey CATEGORY_KEY = new NamespacedKey("ultimate_shop_core", "template_category");
+    private static final NamespacedKey ACTION_KEY = new NamespacedKey("ultimate_shop_core", "template_action");
+    private static final NamespacedKey BUY_KEY = new NamespacedKey("ultimate_shop_core", "buy_price");
+    private static final NamespacedKey SELL_KEY = new NamespacedKey("ultimate_shop_core", "sell_price");
 
     private ItemStack itemStack;
     private Type type;
     private int index;
     private String category;
+    private String action;
+    private double buyPrice;
+    private double sellPrice;
 
     public enum Type {
         DECORATION,
@@ -23,7 +29,9 @@ public class ShopTemplateItemStack {
         CLOSE,
         BACK,
         SHOP_ITEM,
-        CATEGORY;
+        CATEGORY,
+        ACTION,
+        SELECTED_ITEM;
 
         public static Type fromString(String s) {
             try {
@@ -35,18 +43,25 @@ public class ShopTemplateItemStack {
     }
 
     public ShopTemplateItemStack(ItemStack itemStack, Type type, int index) {
-        this(itemStack, type, index, null);
+        this(itemStack, type, index, null, null, 0, 0);
     }
 
     public ShopTemplateItemStack(ItemStack itemStack, Type type, int index, String category) {
+        this(itemStack, type, index, category, null, 0, 0);
+    }
+
+    public ShopTemplateItemStack(ItemStack itemStack, Type type, int index, String category, String action, double buyPrice, double sellPrice) {
         this.itemStack = itemStack;
         this.type = type;
         this.index = index;
         this.category = category;
-        storeTypeAndCategory(itemStack, type, category);
+        this.action = action;
+        this.buyPrice = buyPrice;
+        this.sellPrice = sellPrice;
+        storeData(itemStack, type, category, action, buyPrice, sellPrice);
     }
 
-    private void storeTypeAndCategory(ItemStack item, Type type, String category) {
+    private void storeData(ItemStack item, Type type, String category, String action, double buyPrice, double sellPrice) {
         if (item == null || type == null) return;
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
@@ -55,6 +70,11 @@ public class ShopTemplateItemStack {
         if (category != null) {
             meta.getPersistentDataContainer().set(CATEGORY_KEY, PersistentDataType.STRING, category);
         }
+        if (action != null) {
+            meta.getPersistentDataContainer().set(ACTION_KEY, PersistentDataType.STRING, action);
+        }
+        meta.getPersistentDataContainer().set(BUY_KEY, PersistentDataType.DOUBLE, buyPrice);
+        meta.getPersistentDataContainer().set(SELL_KEY, PersistentDataType.DOUBLE, sellPrice);
         item.setItemMeta(meta);
     }
 
@@ -68,6 +88,36 @@ public class ShopTemplateItemStack {
             return Type.fromString(typeStr);
         }
         return null;
+    }
+
+    public static String extractAction(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) return null;
+        ItemMeta meta = item.getItemMeta();
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        if (container.has(ACTION_KEY, PersistentDataType.STRING)) {
+            return container.get(ACTION_KEY, PersistentDataType.STRING);
+        }
+        return null;
+    }
+
+    public static double extractBuyPrice(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) return 0;
+        ItemMeta meta = item.getItemMeta();
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        if (container.has(BUY_KEY, PersistentDataType.DOUBLE)) {
+            return container.get(BUY_KEY, PersistentDataType.DOUBLE);
+        }
+        return 0;
+    }
+
+    public static double extractSellPrice(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) return 0;
+        ItemMeta meta = item.getItemMeta();
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        if (container.has(SELL_KEY, PersistentDataType.DOUBLE)) {
+            return container.get(SELL_KEY, PersistentDataType.DOUBLE);
+        }
+        return 0;
     }
 
     public static String extractCategory(ItemStack item) {
@@ -87,7 +137,7 @@ public class ShopTemplateItemStack {
 
     public void setItemStack(ItemStack itemStack) {
         this.itemStack = itemStack;
-        storeTypeAndCategory(itemStack, this.type, this.category); // re-store data
+        storeData(itemStack, this.type, this.category, this.action, this.buyPrice, this.sellPrice); // re-store data
     }
 
     public Type getType() {
@@ -96,7 +146,7 @@ public class ShopTemplateItemStack {
 
     public void setType(Type type) {
         this.type = type;
-        storeTypeAndCategory(this.itemStack, type, this.category); // re-store data
+        storeData(this.itemStack, type, this.category, this.action, this.buyPrice, this.sellPrice); // re-store data
     }
 
     public int getIndex() {
@@ -113,6 +163,33 @@ public class ShopTemplateItemStack {
 
     public void setCategory(String category) {
         this.category = category;
-        storeTypeAndCategory(this.itemStack, this.type, category);
+        storeData(this.itemStack, this.type, category, this.action, this.buyPrice, this.sellPrice);
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+        storeData(this.itemStack, this.type, this.category, action, this.buyPrice, this.sellPrice);
+    }
+
+    public double getBuyPrice() {
+        return buyPrice;
+    }
+
+    public void setBuyPrice(double buyPrice) {
+        this.buyPrice = buyPrice;
+        storeData(this.itemStack, this.type, this.category, this.action, buyPrice, this.sellPrice);
+    }
+
+    public double getSellPrice() {
+        return sellPrice;
+    }
+
+    public void setSellPrice(double sellPrice) {
+        this.sellPrice = sellPrice;
+        storeData(this.itemStack, this.type, this.category, this.action, this.buyPrice, sellPrice);
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,4 @@ name: Ultimate_Shop_Core
 version: '1.0-SNAPSHOT'
 main: com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core
 api-version: '1.21'
+depend: [Vault]

--- a/src/main/resources/templates/default/buy_sell.yml
+++ b/src/main/resources/templates/default/buy_sell.yml
@@ -54,6 +54,12 @@ items:
     item:
       type: EMERALD
       display_name: "&aBuy Stack"
+  - slot: 28
+    type: ACTION
+    action: change_mode
+    item:
+      type: LEVER
+      display_name: "&eChange Mode"
   - slot: 32
     type: ACTION
     action: sell_stack

--- a/src/main/resources/templates/default/buy_sell.yml
+++ b/src/main/resources/templates/default/buy_sell.yml
@@ -1,0 +1,67 @@
+rows: 3
+inventory_name: "Buy & Sell"
+items:
+  - slot: 10
+    type: ACTION
+    action: add1
+    item:
+      type: STONE_BUTTON
+      display_name: "&aAdd 1"
+  - slot: 11
+    type: ACTION
+    action: add16
+    item:
+      type: STONE_BUTTON
+      display_name: "&aAdd 16"
+  - slot: 12
+    type: ACTION
+    action: add32
+    item:
+      type: STONE_BUTTON
+      display_name: "&aAdd 32"
+  - slot: 13
+    type: ACTION
+    action: add64
+    item:
+      type: STONE_BUTTON
+      display_name: "&aAdd 64"
+  - slot: 20
+    type: ACTION
+    action: buy
+    item:
+      type: EMERALD_BLOCK
+      display_name: "&aBuy"
+  - slot: 24
+    type: ACTION
+    action: sell
+    item:
+      type: REDSTONE_BLOCK
+      display_name: "&cSell"
+  - slot: 22
+    type: SELECTED_ITEM
+    item:
+      type: DIAMOND
+      display_name: "&fItem"
+  - slot: 31
+    type: ACTION
+    action: input
+    item:
+      type: PAPER
+      display_name: "&eEnter Amount"
+  - slot: 30
+    type: ACTION
+    action: buy_stack
+    item:
+      type: EMERALD
+      display_name: "&aBuy Stack"
+  - slot: 32
+    type: ACTION
+    action: sell_stack
+    item:
+      type: REDSTONE
+      display_name: "&cSell Stack"
+  - slot: 26
+    type: BACK
+    item:
+      type: ARROW
+      display_name: "&aBack"

--- a/src/main/resources/templates/default/categories/ores.yml
+++ b/src/main/resources/templates/default/categories/ores.yml
@@ -1,0 +1,15 @@
+rows: 3
+inventory_name: "Ores"
+items:
+  - slot: 10
+    type: SHOP_ITEM
+    buy_price: 100
+    sell_price: 50
+    item:
+      type: DIAMOND
+      display_name: "&bDiamond"
+  - slot: 26
+    type: BACK
+    item:
+      type: ARROW
+      display_name: "&aBack"

--- a/src/main/resources/templates/default/shop.yml
+++ b/src/main/resources/templates/default/shop.yml
@@ -1,20 +1,14 @@
 rows: 5
-type: "SHOP"
 inventory_name: "Shop"
 items:
-  - slot: 10
-    category: "food"
+  - slot: 11
     type: CATEGORY
+    category: "categories/ores"
     item:
-      type: APPLE
-      display_name: "§aFood Category"
-  - slot: [19, "20-22", 25]
-    type: DECORATION
-    item:
-      type: GRAY_STAINED_GLASS_PANE
-      display_name: "§r"
+      type: IRON_ORE
+      display_name: "&7Ores"
   - slot: 45
     type: CLOSE
     item:
       type: BARRIER
-      display_name: "§cClose"
+      display_name: "&cClose"


### PR DESCRIPTION
## Summary
- add Vault economy hook
- introduce BuySellInventory holder
- extend template system with actions and prices
- implement buy/sell GUI behaviour
- add default templates for categories and buy/sell menu

## Testing
- `gradle build` *(fails: Could not resolve net.wesjd:anvilgui)*

------
https://chatgpt.com/codex/tasks/task_e_6856c369a310833094cfaee708e67eda