### PR TITLE
Add buy/sell GUI system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ repositories {
 
 dependencies {
     compileOnly("org.spigotmc:spigot-api:1.17-R0.1-SNAPSHOT")
+    compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
     implementation 'io.github.revxrsal:lamp.common:4.0.0-rc.12'
     implementation 'io.github.revxrsal:lamp.bukkit:4.0.0-rc.12'
     // Use latest AnvilGUI version compatible with MC 1.17+

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ repositories {
     maven {
         url = "https://repo.codemc.io/repository/maven-snapshots/"
     }
+    maven {
+        url = "https://repo.dmulloy2.net/repository/public/"
+    }
 }
 
 dependencies {
@@ -31,8 +34,7 @@ dependencies {
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
     implementation 'io.github.revxrsal:lamp.common:4.0.0-rc.12'
     implementation 'io.github.revxrsal:lamp.bukkit:4.0.0-rc.12'
-    // Use latest AnvilGUI version compatible with MC 1.17+
-    implementation 'net.wesjd:anvilgui:1.10.5-SNAPSHOT'
+    compileOnly 'com.comphenix.protocol:ProtocolLib:5.2.0-SNAPSHOT'
 }
 
 def targetJavaVersion = 17
@@ -63,10 +65,7 @@ tasks {
         // Relocate only Lamp
         relocate "io.github.revxrsal.lamp", "com.hmmbo.shaded.lamp"
 
-        // EXCLUDE AnvilGUI from the final shaded jar
-        dependencies {
-            exclude(dependency("net.wesjd:anvilgui"))
-        }
+        // No special dependency relocations
     }
 
 

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/Ultimate_Shop_Core.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/Ultimate_Shop_Core.java
@@ -3,6 +3,7 @@ package com.hmmbo.ultimate_Shop_Core;
 import com.hmmbo.ultimate_Shop_Core.shop.listeners.ShopMenuListener;
 import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
 import com.hmmbo.ultimate_Shop_Core.utils.commands.ShopCommand;
+import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -13,6 +14,7 @@ import revxrsal.commands.bukkit.actor.BukkitCommandActor;
 public final class Ultimate_Shop_Core extends JavaPlugin {
 
     public static Plugin instance;
+    public static Economy economy;
 
     @Override
     public void onEnable() {
@@ -20,9 +22,15 @@ public final class Ultimate_Shop_Core extends JavaPlugin {
         // Plugin startup logic
         saveDefaultConfig();
         saveResource("templates/default/shop.yml", false);
-        saveResource("templates/default/food.yml", false);
+        saveResource("templates/default/buy_sell.yml", false);
+        saveResource("templates/default/categories/ores.yml", false);
+        saveResource("templates/default/categories/blocks.yml", false);
         Lamp<BukkitCommandActor> lamp = BukkitLamp.builder(this).build();
         lamp.register(new ShopCommand());
+
+        if (getServer().getPluginManager().getPlugin("Vault") != null) {
+            economy = getServer().getServicesManager().getRegistration(Economy.class).getProvider();
+        }
 
 
         //Managers

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/Ultimate_Shop_Core.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/Ultimate_Shop_Core.java
@@ -3,6 +3,7 @@ package com.hmmbo.ultimate_Shop_Core;
 import com.hmmbo.ultimate_Shop_Core.shop.listeners.ShopMenuListener;
 import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
 import com.hmmbo.ultimate_Shop_Core.utils.commands.ShopCommand;
+import com.hmmbo.ultimate_Shop_Core.utils.sign.SignInput;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
@@ -35,6 +36,7 @@ public final class Ultimate_Shop_Core extends JavaPlugin {
 
         //Managers
         new ShopTemplateManager(this);
+        SignInput.init(this);
 
         // Listeners
         Bukkit.getPluginManager().registerEvents(new ShopMenuListener(), this);

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/datatypes/Custom_Inventory.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/datatypes/Custom_Inventory.java
@@ -7,17 +7,56 @@ import org.bukkit.inventory.InventoryHolder;
 public class Custom_Inventory implements InventoryHolder {
 
     private final ShopTemplate template;
+    private final org.bukkit.inventory.ItemStack dynamicItem;
+    private final double buyPrice;
+    private final double sellPrice;
+    private int amount = 1;
 
     public Custom_Inventory(ShopTemplate template) {
+        this(template, null, 0, 0);
+    }
+
+    public Custom_Inventory(ShopTemplate template, org.bukkit.inventory.ItemStack item, double buyPrice, double sellPrice) {
         this.template = template;
+        this.dynamicItem = item;
+        this.buyPrice = buyPrice;
+        this.sellPrice = sellPrice;
     }
 
     @Override
     public Inventory getInventory() {
-        return template.createInventory(); // optional
+        if (dynamicItem != null) {
+            return template.createInventory(dynamicItem, buyPrice, sellPrice);
+        }
+        return template.createInventory();
     }
 
     public ShopTemplate getTemplate() {
         return template;
+    }
+
+    public org.bukkit.inventory.ItemStack getDynamicItem() {
+        return dynamicItem;
+    }
+
+    public double getBuyPrice() {
+        return buyPrice;
+    }
+
+    public double getSellPrice() {
+        return sellPrice;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public void addAmount(int add) {
+        this.amount += add;
+        if (this.amount < 1) this.amount = 1;
+    }
+
+    public void setAmount(int amount) {
+        this.amount = Math.max(1, amount);
     }
 }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopMenuListener.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopMenuListener.java
@@ -1,13 +1,17 @@
 package com.hmmbo.ultimate_Shop_Core.shop.listeners;
 
+import com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core;
 import com.hmmbo.ultimate_Shop_Core.datatypes.Custom_Inventory;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplate;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplateItemStack;
 import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
+import net.wesjd.anvilgui.AnvilGUI;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 public class ShopMenuListener implements Listener {
 
@@ -22,6 +26,8 @@ public class ShopMenuListener implements Listener {
 
             if (type == null) return;
 
+            Player player = (Player) event.getWhoClicked();
+
             switch (type) {
                 case CATEGORY -> {
                     String category = ShopTemplateItemStack.extractCategory(event.getCurrentItem());
@@ -29,17 +35,79 @@ public class ShopMenuListener implements Listener {
                     String folder = template.getName().split("/")[0];
                     ShopTemplate cat = ShopTemplateManager.get().getTemplate(folder, category);
                     if (cat != null) {
-                        event.getWhoClicked().openInventory(cat.createInventory());
+                        player.openInventory(cat.createInventory());
+                    }
+                }
+                case SHOP_ITEM -> {
+                    ItemStack clicked = event.getCurrentItem();
+                    double buy = ShopTemplateItemStack.extractBuyPrice(clicked);
+                    double sell = ShopTemplateItemStack.extractSellPrice(clicked);
+                    String folder = template.getName().split("/")[0];
+                    ShopTemplate bs = ShopTemplateManager.get().getTemplate(folder, "buy_sell");
+                    if (bs != null) {
+                        player.openInventory(bs.createInventory(clicked, buy, sell));
+                    }
+                }
+                case ADD1 -> {
+                    shopHolder.addAmount(1);
+                }
+                case ADD16 -> shopHolder.addAmount(16);
+                case ADD32 -> shopHolder.addAmount(32);
+                case ADD64 -> shopHolder.addAmount(64);
+                case INPUT -> {
+                    new AnvilGUI.Builder()
+                            .onClick((slot, state) -> {
+                                if (slot != AnvilGUI.Slot.OUTPUT) return java.util.Collections.emptyList();
+                                try {
+                                    int amt = Integer.parseInt(state.getText());
+                                    shopHolder.setAmount(amt);
+                                } catch (NumberFormatException ignored) {
+                                    player.sendMessage("Invalid amount");
+                                }
+                                return java.util.List.of(AnvilGUI.ResponseAction.close());
+                            })
+                            .onClose(state -> player.sendMessage("Closed Inventory"))
+                            .text("5-10 or 8")
+                            .title("Enter Amount")
+                            .plugin(Ultimate_Shop_Core.instance)
+                            .open(player);
+                }
+                case BUY -> {
+                    if (Ultimate_Shop_Core.economy != null) {
+                        double cost = shopHolder.getBuyPrice() * shopHolder.getAmount();
+                        if (Ultimate_Shop_Core.economy.getBalance(player) >= cost) {
+                            Ultimate_Shop_Core.economy.withdrawPlayer(player, cost);
+                            ItemStack item = shopHolder.getDynamicItem().clone();
+                            item.setAmount(shopHolder.getAmount());
+                            player.getInventory().addItem(item);
+                            player.sendMessage("You bought " + shopHolder.getAmount() + " " + item.getType() + " for $" + cost);
+                        } else {
+                            player.sendMessage("Not enough money!");
+                        }
+                    }
+                }
+                case SELL -> {
+                    ItemStack item = shopHolder.getDynamicItem().clone();
+                    item.setAmount(shopHolder.getAmount());
+                    if (player.getInventory().containsAtLeast(item, shopHolder.getAmount())) {
+                        player.getInventory().removeItem(item);
+                        double gain = shopHolder.getSellPrice() * shopHolder.getAmount();
+                        if (Ultimate_Shop_Core.economy != null) {
+                            Ultimate_Shop_Core.economy.depositPlayer(player, gain);
+                        }
+                        player.sendMessage("You sold " + shopHolder.getAmount() + " " + item.getType() + " for $" + gain);
+                    } else {
+                        player.sendMessage("You don't have enough items!");
                     }
                 }
                 case BACK -> {
                     String folder = template.getName().split("/")[0];
                     ShopTemplate rootTemplate = ShopTemplateManager.get().getTemplate(folder, "shop");
                     if (rootTemplate != null) {
-                        event.getWhoClicked().openInventory(rootTemplate.createInventory());
+                        player.openInventory(rootTemplate.createInventory());
                     }
                 }
-                case CLOSE -> event.getWhoClicked().closeInventory();
+                case CLOSE -> player.closeInventory();
                 default -> {
                 }
             }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopMenuListener.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopMenuListener.java
@@ -5,7 +5,7 @@ import com.hmmbo.ultimate_Shop_Core.datatypes.Custom_Inventory;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplate;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplateItemStack;
 import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
-import net.wesjd.anvilgui.AnvilGUI;
+import com.hmmbo.ultimate_Shop_Core.utils.sign.SignInput;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -57,22 +57,15 @@ public class ShopMenuListener implements Listener {
                 case ADD32 -> shopHolder.addAmount(32);
                 case ADD64 -> shopHolder.addAmount(64);
                 case INPUT -> {
-                    new AnvilGUI.Builder()
-                            .onClick((slot, state) -> {
-                                if (slot != AnvilGUI.Slot.OUTPUT) return java.util.Collections.emptyList();
-                                try {
-                                    int amt = Integer.parseInt(state.getText());
-                                    shopHolder.setAmount(amt);
-                                } catch (NumberFormatException ignored) {
-                                    player.sendMessage("Invalid amount");
-                                }
-                                return java.util.List.of(AnvilGUI.ResponseAction.close());
-                            })
-                            .onClose(state -> player.sendMessage("Closed Inventory"))
-                            .text("5-10 or 8")
-                            .title("Enter Amount")
-                            .plugin(Ultimate_Shop_Core.instance)
-                            .open(player);
+                    SignInput.open(player, lines -> {
+                        if (lines.length == 0) return;
+                        try {
+                            int amt = Integer.parseInt(lines[0]);
+                            shopHolder.setAmount(amt);
+                        } catch (NumberFormatException ignored) {
+                            player.sendMessage("Invalid amount");
+                        }
+                    });
                 }
                 case BUY -> {
                     if (Ultimate_Shop_Core.economy != null) {

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/BuySellItemStack.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/BuySellItemStack.java
@@ -1,0 +1,26 @@
+package com.hmmbo.ultimate_Shop_Core.shop.template;
+
+import org.bukkit.inventory.ItemStack;
+
+public class BuySellItemStack extends ShopTemplateItemStack {
+    public enum BuySellType {
+        ADD1,
+        ADD16,
+        ADD32,
+        ADD64,
+        BUY,
+        SELL,
+        BUY_STACK,
+        SELL_STACK,
+        INPUT,
+        CHANGE_MODE,
+        SHOP_ITEM,
+        CLOSE,
+        BACK,
+        DECORATION
+    }
+
+    public BuySellItemStack(ItemStack itemStack, BuySellType type, int index, double buyPrice, double sellPrice) {
+        super(itemStack, Type.valueOf(type.name()), index, null, buyPrice, sellPrice);
+    }
+}

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/BuySellTemplate.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/BuySellTemplate.java
@@ -1,0 +1,7 @@
+package com.hmmbo.ultimate_Shop_Core.shop.template;
+
+public class BuySellTemplate extends ShopTemplate {
+    public BuySellTemplate(int rows, String name, String inventoryName, Type type) {
+        super(rows, name, inventoryName, type);
+    }
+}

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/CategoryItemStack.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/CategoryItemStack.java
@@ -1,0 +1,18 @@
+package com.hmmbo.ultimate_Shop_Core.shop.template;
+
+import org.bukkit.inventory.ItemStack;
+
+public class CategoryItemStack extends ShopTemplateItemStack {
+    public enum CategoryType {
+        DECORATION,
+        NEXT,
+        PREV,
+        CLOSE,
+        BACK,
+        SHOP_ITEM
+    }
+
+    public CategoryItemStack(ItemStack itemStack, CategoryType type, int index, double buyPrice, double sellPrice) {
+        super(itemStack, Type.valueOf(type.name()), index, null, buyPrice, sellPrice);
+    }
+}

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/CategoryTemplate.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/CategoryTemplate.java
@@ -1,0 +1,7 @@
+package com.hmmbo.ultimate_Shop_Core.shop.template;
+
+public class CategoryTemplate extends ShopTemplate {
+    public CategoryTemplate(int rows, String name, String inventoryName, Type type) {
+        super(rows, name, inventoryName, type);
+    }
+}

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopMenuItemStack.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopMenuItemStack.java
@@ -1,0 +1,18 @@
+package com.hmmbo.ultimate_Shop_Core.shop.template;
+
+import org.bukkit.inventory.ItemStack;
+
+public class ShopMenuItemStack extends ShopTemplateItemStack {
+    public enum MenuType {
+        DECORATION,
+        NEXT,
+        PREV,
+        CLOSE,
+        BACK,
+        CATEGORY
+    }
+
+    public ShopMenuItemStack(ItemStack itemStack, MenuType type, int index, String category) {
+        super(itemStack, Type.valueOf(type.name()), index, category, 0, 0);
+    }
+}

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopMenuTemplate.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopMenuTemplate.java
@@ -1,0 +1,7 @@
+package com.hmmbo.ultimate_Shop_Core.shop.template;
+
+public class ShopMenuTemplate extends ShopTemplate {
+    public ShopMenuTemplate(int rows, String name, String inventoryName, Type type) {
+        super(rows, name, inventoryName, type);
+    }
+}

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplate.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplate.java
@@ -60,6 +60,23 @@ public class ShopTemplate {
         return inventory;
     }
 
+    public Inventory createInventory(ItemStack dynamicItem, double buyPrice, double sellPrice) {
+        int size = rows * 9;
+        String title = inventoryName != null ? inventoryName : name;
+        Inventory inventory = Bukkit.createInventory(new Custom_Inventory(this, dynamicItem, buyPrice, sellPrice), size, title);
+        for (ShopTemplateItemStack templateItem : items) {
+            int index = templateItem.getIndex();
+            ItemStack stack = templateItem.getItemStack();
+            if (templateItem.getType() == ShopTemplateItemStack.Type.SHOP_ITEM && dynamicItem != null) {
+                stack = dynamicItem.clone();
+            }
+            if (index >= 0 && index < size) {
+                inventory.setItem(index, stack);
+            }
+        }
+        return inventory;
+    }
+
     public int getRows() {
         return rows;
     }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplateItemStack.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplateItemStack.java
@@ -8,6 +8,11 @@ import org.bukkit.persistence.PersistentDataType;
 
 public class ShopTemplateItemStack {
 
+    /**
+     * Namespaced keys used for storing template data on an {@link ItemStack}.
+     * Using literal namespaces keeps the items valid even before the plugin is
+     * fully initialised.
+     */
     private static final NamespacedKey TYPE_KEY = new NamespacedKey("ultimate_shop_core", "template_type");
     private static final NamespacedKey CATEGORY_KEY = new NamespacedKey("ultimate_shop_core", "template_category");
     private static final NamespacedKey BUY_PRICE_KEY = new NamespacedKey("ultimate_shop_core", "buy_price");

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplateItemStack.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplateItemStack.java
@@ -10,11 +10,15 @@ public class ShopTemplateItemStack {
 
     private static final NamespacedKey TYPE_KEY = new NamespacedKey("ultimate_shop_core", "template_type");
     private static final NamespacedKey CATEGORY_KEY = new NamespacedKey("ultimate_shop_core", "template_category");
+    private static final NamespacedKey BUY_PRICE_KEY = new NamespacedKey("ultimate_shop_core", "buy_price");
+    private static final NamespacedKey SELL_PRICE_KEY = new NamespacedKey("ultimate_shop_core", "sell_price");
 
     private ItemStack itemStack;
     private Type type;
     private int index;
     private String category;
+    private double buyPrice;
+    private double sellPrice;
 
     public enum Type {
         DECORATION,
@@ -23,7 +27,17 @@ public class ShopTemplateItemStack {
         CLOSE,
         BACK,
         SHOP_ITEM,
-        CATEGORY;
+        CATEGORY,
+        ADD1,
+        ADD16,
+        ADD32,
+        ADD64,
+        BUY,
+        SELL,
+        BUY_STACK,
+        SELL_STACK,
+        INPUT,
+        CHANGE_MODE;
 
         public static Type fromString(String s) {
             try {
@@ -35,18 +49,24 @@ public class ShopTemplateItemStack {
     }
 
     public ShopTemplateItemStack(ItemStack itemStack, Type type, int index) {
-        this(itemStack, type, index, null);
+        this(itemStack, type, index, null, 0, 0);
     }
 
     public ShopTemplateItemStack(ItemStack itemStack, Type type, int index, String category) {
+        this(itemStack, type, index, category, 0, 0);
+    }
+
+    public ShopTemplateItemStack(ItemStack itemStack, Type type, int index, String category, double buyPrice, double sellPrice) {
         this.itemStack = itemStack;
         this.type = type;
         this.index = index;
         this.category = category;
-        storeTypeAndCategory(itemStack, type, category);
+        this.buyPrice = buyPrice;
+        this.sellPrice = sellPrice;
+        storeTypeAndCategory(itemStack, type, category, buyPrice, sellPrice);
     }
 
-    private void storeTypeAndCategory(ItemStack item, Type type, String category) {
+    private void storeTypeAndCategory(ItemStack item, Type type, String category, double buy, double sell) {
         if (item == null || type == null) return;
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
@@ -55,6 +75,8 @@ public class ShopTemplateItemStack {
         if (category != null) {
             meta.getPersistentDataContainer().set(CATEGORY_KEY, PersistentDataType.STRING, category);
         }
+        if (buy > 0) meta.getPersistentDataContainer().set(BUY_PRICE_KEY, PersistentDataType.DOUBLE, buy);
+        if (sell > 0) meta.getPersistentDataContainer().set(SELL_PRICE_KEY, PersistentDataType.DOUBLE, sell);
         item.setItemMeta(meta);
     }
 
@@ -81,13 +103,33 @@ public class ShopTemplateItemStack {
         return null;
     }
 
+    public static double extractBuyPrice(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) return 0;
+        ItemMeta meta = item.getItemMeta();
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        if (container.has(BUY_PRICE_KEY, PersistentDataType.DOUBLE)) {
+            return container.get(BUY_PRICE_KEY, PersistentDataType.DOUBLE);
+        }
+        return 0;
+    }
+
+    public static double extractSellPrice(ItemStack item) {
+        if (item == null || !item.hasItemMeta()) return 0;
+        ItemMeta meta = item.getItemMeta();
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        if (container.has(SELL_PRICE_KEY, PersistentDataType.DOUBLE)) {
+            return container.get(SELL_PRICE_KEY, PersistentDataType.DOUBLE);
+        }
+        return 0;
+    }
+
     public ItemStack getItemStack() {
         return itemStack;
     }
 
     public void setItemStack(ItemStack itemStack) {
         this.itemStack = itemStack;
-        storeTypeAndCategory(itemStack, this.type, this.category); // re-store data
+        storeTypeAndCategory(itemStack, this.type, this.category, this.buyPrice, this.sellPrice); // re-store data
     }
 
     public Type getType() {
@@ -96,7 +138,7 @@ public class ShopTemplateItemStack {
 
     public void setType(Type type) {
         this.type = type;
-        storeTypeAndCategory(this.itemStack, type, this.category); // re-store data
+        storeTypeAndCategory(this.itemStack, type, this.category, this.buyPrice, this.sellPrice); // re-store data
     }
 
     public int getIndex() {
@@ -113,6 +155,14 @@ public class ShopTemplateItemStack {
 
     public void setCategory(String category) {
         this.category = category;
-        storeTypeAndCategory(this.itemStack, this.type, category);
+        storeTypeAndCategory(this.itemStack, this.type, category, this.buyPrice, this.sellPrice);
+    }
+
+    public double getBuyPrice() {
+        return buyPrice;
+    }
+
+    public double getSellPrice() {
+        return sellPrice;
     }
 }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/sign/SignInput.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/sign/SignInput.java
@@ -1,0 +1,69 @@
+package com.hmmbo.ultimate_Shop_Core.utils.sign;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.events.PacketListener;
+import com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.util.BlockVector;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * Utility for prompting players with a sign editor and retrieving the input.
+ */
+public class SignInput {
+    private static final Map<UUID, Consumer<String[]>> callbacks = new ConcurrentHashMap<>();
+    private static PacketListener listener;
+
+    /**
+     * Initialise the packet listener. Call this once in plugin onEnable.
+     */
+    public static void init(Plugin plugin) {
+        if (listener != null) return;
+        listener = new PacketAdapter(plugin, PacketType.Play.Client.UPDATE_SIGN) {
+            @Override
+            public void onPacketReceiving(PacketEvent event) {
+                UUID id = event.getPlayer().getUniqueId();
+                Consumer<String[]> cb = callbacks.remove(id);
+                if (cb != null) {
+                    String[] lines = event.getPacket().getStringArrays().read(0);
+                    cb.accept(lines);
+                    Location loc = event.getPlayer().getLocation().getBlock().getLocation();
+                    event.getPlayer().sendBlockChange(loc, Material.AIR.createBlockData());
+                    event.setCancelled(true);
+                }
+            }
+        };
+        ProtocolLibrary.getProtocolManager().addPacketListener(listener);
+    }
+
+    /**
+     * Opens a sign editor for the player. The callback is invoked with the entered lines.
+     */
+    public static void open(Player player, Consumer<String[]> callback) {
+        if (listener == null) {
+            init(Ultimate_Shop_Core.instance);
+        }
+        Location loc = player.getLocation();
+        loc = new Location(player.getWorld(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+        BlockVector pos = new BlockVector(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+        BlockData data = Material.OAK_SIGN.createBlockData();
+        player.sendBlockChange(loc, data);
+
+        var openSign = ProtocolLibrary.getProtocolManager().createPacket(PacketType.Play.Server.OPEN_SIGN_EDITOR);
+        openSign.getBlockPositionModifier().write(0, pos);
+        ProtocolLibrary.getProtocolManager().sendServerPacket(player, openSign);
+
+        callbacks.put(player.getUniqueId(), callback);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,4 +2,4 @@ name: Ultimate_Shop_Core
 version: '1.0-SNAPSHOT'
 main: com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core
 api-version: '1.21'
-depend: [Vault]
+depend: [Vault, ProtocolLib]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,4 @@ name: Ultimate_Shop_Core
 version: '1.0-SNAPSHOT'
 main: com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core
 api-version: '1.21'
+depend: [Vault]

--- a/src/main/resources/templates/default/buy_sell.yml
+++ b/src/main/resources/templates/default/buy_sell.yml
@@ -1,0 +1,43 @@
+rows: 3
+inventory_name: "Buy & Sell"
+items:
+  - slot: 10
+    type: ADD1
+    item:
+      type: GREEN_WOOL
+      display_name: "&aAdd 1"
+  - slot: 11
+    type: ADD16
+    item:
+      type: GREEN_WOOL
+      display_name: "&aAdd 16"
+  - slot: 12
+    type: ADD32
+    item:
+      type: GREEN_WOOL
+      display_name: "&aAdd 32"
+  - slot: 14
+    type: ADD64
+    item:
+      type: GREEN_WOOL
+      display_name: "&aAdd 64"
+  - slot: 15
+    type: BUY
+    item:
+      type: EMERALD_BLOCK
+      display_name: "&aBuy"
+  - slot: 16
+    type: SELL
+    item:
+      type: REDSTONE_BLOCK
+      display_name: "&cSell"
+  - slot: 13
+    type: SHOP_ITEM
+    item:
+      type: STONE
+      display_name: "&fItem"
+  - slot: 22
+    type: CLOSE
+    item:
+      type: BARRIER
+      display_name: "&cClose"

--- a/src/main/resources/templates/default/buy_sell.yml
+++ b/src/main/resources/templates/default/buy_sell.yml
@@ -21,6 +21,21 @@ items:
     item:
       type: GREEN_WOOL
       display_name: "&aAdd 64"
+  - slot: 20
+    type: BUY_STACK
+    item:
+      type: EMERALD
+      display_name: "&aBuy Stack"
+  - slot: 21
+    type: SELL_STACK
+    item:
+      type: REDSTONE
+      display_name: "&cSell Stack"
+  - slot: 22
+    type: INPUT
+    item:
+      type: PAPER
+      display_name: "&eEnter Amount"
   - slot: 15
     type: BUY
     item:
@@ -36,7 +51,7 @@ items:
     item:
       type: STONE
       display_name: "&fItem"
-  - slot: 22
+  - slot: 26
     type: CLOSE
     item:
       type: BARRIER

--- a/src/main/resources/templates/default/categories/blocks.yml
+++ b/src/main/resources/templates/default/categories/blocks.yml
@@ -1,0 +1,15 @@
+rows: 5
+inventory_name: "Blocks"
+items:
+  - slot: 10
+    type: SHOP_ITEM
+    item:
+      type: STONE
+      display_name: "&7Stone"
+    buy_price: 1
+    sell_price: 0.5
+  - slot: 19
+    type: BACK
+    item:
+      type: ARROW
+      display_name: "&aBack"

--- a/src/main/resources/templates/default/categories/ores.yml
+++ b/src/main/resources/templates/default/categories/ores.yml
@@ -1,0 +1,15 @@
+rows: 5
+inventory_name: "Ores"
+items:
+  - slot: 10
+    type: SHOP_ITEM
+    item:
+      type: DIAMOND
+      display_name: "&bDiamond"
+    buy_price: 50
+    sell_price: 25
+  - slot: 19
+    type: BACK
+    item:
+      type: ARROW
+      display_name: "&aBack"

--- a/src/main/resources/templates/default/shop.yml
+++ b/src/main/resources/templates/default/shop.yml
@@ -3,11 +3,17 @@ type: "SHOP"
 inventory_name: "Shop"
 items:
   - slot: 10
-    category: "food"
+    category: "categories/ores"
     type: CATEGORY
     item:
-      type: APPLE
-      display_name: "§aFood Category"
+      type: DIAMOND_ORE
+      display_name: "§bOres"
+  - slot: 11
+    category: "categories/blocks"
+    type: CATEGORY
+    item:
+      type: STONE
+      display_name: "§7Blocks"
   - slot: [19, "20-22", 25]
     type: DECORATION
     item:


### PR DESCRIPTION
## Summary
- implement a recursive template loader and new ShopTemplateItemStack data (price & new types)
- support dynamic buy/sell inventory through `Custom_Inventory` and `ShopTemplate`
- handle inventory actions in `ShopMenuListener`
- hook Vault in main plugin
- add buy/sell templates and example categories
- update build script and plugin metadata
- split template classes for menu, category, and buy/sell

## Testing
- `gradle build` *(fails: Could not resolve anvilgui due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6857ba51be7c8330b05385802eb4ec98