### PR TITLE
Refactor plugin structure and sign GUI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ repositories {
     }
     maven { url "https://repo.dmulloy2.net/repository/public/" }
     maven { url 'https://jitpack.io' }
+    maven {
+        url 'https://repo.retrooper.dev/repository/maven-public/'
+    }
 }
 
 dependencies {
@@ -33,7 +36,7 @@ dependencies {
     compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
     implementation 'io.github.revxrsal:lamp.common:4.0.0-rc.12'
     implementation 'io.github.revxrsal:lamp.bukkit:4.0.0-rc.12'
-    compileOnly 'com.comphenix.protocol:ProtocolLib:5.1.0'
+    implementation 'com.github.retrooper.packetevents:packetevents-bukkit:2.0.2'
 }
 
 def targetJavaVersion = 17

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/UltimateShopCore.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/UltimateShopCore.java
@@ -1,6 +1,6 @@
 package com.hmmbo.ultimate_Shop_Core;
 
-import com.hmmbo.ultimate_Shop_Core.shop.listeners.ShopMenuListener;
+import com.hmmbo.ultimate_Shop_Core.shop.listeners.ShopInventoryClickListener;
 import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
 import com.hmmbo.ultimate_Shop_Core.utils.commands.ShopCommand;
 import com.hmmbo.ultimate_Shop_Core.utils.sign.SignInput;
@@ -12,7 +12,10 @@ import revxrsal.commands.Lamp;
 import revxrsal.commands.bukkit.BukkitLamp;
 import revxrsal.commands.bukkit.actor.BukkitCommandActor;
 
-public final class Ultimate_Shop_Core extends JavaPlugin {
+/**
+ * Main plugin entry.
+ */
+public final class UltimateShopCore extends JavaPlugin {
 
     public static Plugin instance;
     public static Economy economy;
@@ -39,7 +42,7 @@ public final class Ultimate_Shop_Core extends JavaPlugin {
         SignInput.init(this);
 
         // Listeners
-        Bukkit.getPluginManager().registerEvents(new ShopMenuListener(), this);
+        Bukkit.getPluginManager().registerEvents(new ShopInventoryClickListener(), this);
 
     }
 

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/datatypes/CustomInventory.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/datatypes/CustomInventory.java
@@ -4,7 +4,10 @@ import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplate;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 
-public class Custom_Inventory implements InventoryHolder {
+/**
+ * Holder for dynamic inventory instances used by shop GUIs.
+ */
+public class CustomInventory implements InventoryHolder {
 
     private final ShopTemplate template;
     private final org.bukkit.inventory.ItemStack dynamicItem;
@@ -13,11 +16,11 @@ public class Custom_Inventory implements InventoryHolder {
     private int amount = 1;
     private boolean stackMode = false;
 
-    public Custom_Inventory(ShopTemplate template) {
+    public CustomInventory(ShopTemplate template) {
         this(template, null, 0, 0);
     }
 
-    public Custom_Inventory(ShopTemplate template, org.bukkit.inventory.ItemStack item, double buyPrice, double sellPrice) {
+    public CustomInventory(ShopTemplate template, org.bukkit.inventory.ItemStack item, double buyPrice, double sellPrice) {
         this.template = template;
         this.dynamicItem = item;
         this.buyPrice = buyPrice;

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopInventoryClickListener.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/listeners/ShopInventoryClickListener.java
@@ -1,7 +1,7 @@
 package com.hmmbo.ultimate_Shop_Core.shop.listeners;
 
-import com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core;
-import com.hmmbo.ultimate_Shop_Core.datatypes.Custom_Inventory;
+import com.hmmbo.ultimate_Shop_Core.UltimateShopCore;
+import com.hmmbo.ultimate_Shop_Core.datatypes.CustomInventory;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplate;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplateItemStack;
 import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
@@ -14,13 +14,16 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-public class ShopMenuListener implements Listener {
+/**
+ * Handles inventory click interactions for the shop menus.
+ */
+public class ShopInventoryClickListener implements Listener {
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
         Inventory inv = event.getInventory();
 
-        if (inv.getHolder() instanceof Custom_Inventory shopHolder) {
+        if (inv.getHolder() instanceof CustomInventory shopHolder) {
             if (event.getCurrentItem() == null) {
                 event.setCancelled(true);
                 return;
@@ -52,7 +55,7 @@ public class ShopMenuListener implements Listener {
                     ShopTemplate bs = ShopTemplateManager.get().getTemplate(folder, "buy_sell");
                     if (bs != null) {
                         Inventory newInv = bs.createInventory(clicked, buy, sell);
-                        Custom_Inventory newHolder = (Custom_Inventory) newInv.getHolder();
+                        CustomInventory newHolder = (CustomInventory) newInv.getHolder();
                         applyMode(newInv, newHolder.isStackMode(), bs.hasChangeMode());
                         updateAmountDisplay(newInv, bs, clicked, newHolder.getAmount());
                         player.openInventory(newInv);
@@ -77,7 +80,7 @@ public class ShopMenuListener implements Listener {
                 case CHANGE_MODE -> {
                     boolean mode = shopHolder.toggleStackMode();
                     Inventory newInv = template.createInventory(shopHolder.getDynamicItem(), shopHolder.getBuyPrice(), shopHolder.getSellPrice());
-                    Custom_Inventory newHolder = (Custom_Inventory) newInv.getHolder();
+                    CustomInventory newHolder = (CustomInventory) newInv.getHolder();
                     newHolder.setAmount(shopHolder.getAmount());
                     newHolder.setStackMode(mode);
                     applyMode(newInv, mode, template.hasChangeMode());
@@ -94,7 +97,7 @@ public class ShopMenuListener implements Listener {
                             player.sendMessage("Invalid amount");
                         }
                         Inventory newInv = template.createInventory(shopHolder.getDynamicItem(), shopHolder.getBuyPrice(), shopHolder.getSellPrice());
-                        Custom_Inventory newHolder = (Custom_Inventory) newInv.getHolder();
+                        CustomInventory newHolder = (CustomInventory) newInv.getHolder();
                         newHolder.setAmount(shopHolder.getAmount());
                         newHolder.setStackMode(shopHolder.isStackMode());
                         applyMode(newInv, newHolder.isStackMode(), template.hasChangeMode());
@@ -103,10 +106,10 @@ public class ShopMenuListener implements Listener {
                     });
                 }
                 case BUY -> {
-                    if (Ultimate_Shop_Core.economy != null) {
+                    if (UltimateShopCore.economy != null) {
                         double cost = shopHolder.getBuyPrice() * shopHolder.getAmount();
-                        if (Ultimate_Shop_Core.economy.getBalance(player) >= cost) {
-                            Ultimate_Shop_Core.economy.withdrawPlayer(player, cost);
+                        if (UltimateShopCore.economy.getBalance(player) >= cost) {
+                            UltimateShopCore.economy.withdrawPlayer(player, cost);
                             ItemStack item = shopHolder.getDynamicItem().clone();
                             item.setAmount(shopHolder.getAmount());
                             player.getInventory().addItem(item);
@@ -117,11 +120,11 @@ public class ShopMenuListener implements Listener {
                     }
                 }
                 case BUY_STACK -> {
-                    if (Ultimate_Shop_Core.economy != null) {
+                    if (UltimateShopCore.economy != null) {
                         int amt = 64;
                         double cost = shopHolder.getBuyPrice() * amt;
-                        if (Ultimate_Shop_Core.economy.getBalance(player) >= cost) {
-                            Ultimate_Shop_Core.economy.withdrawPlayer(player, cost);
+                        if (UltimateShopCore.economy.getBalance(player) >= cost) {
+                            UltimateShopCore.economy.withdrawPlayer(player, cost);
                             ItemStack item = shopHolder.getDynamicItem().clone();
                             item.setAmount(amt);
                             player.getInventory().addItem(item);
@@ -137,8 +140,8 @@ public class ShopMenuListener implements Listener {
                     if (player.getInventory().containsAtLeast(check, amt)) {
                         player.getInventory().removeItem(check);
                         double gain = shopHolder.getSellPrice() * amt;
-                        if (Ultimate_Shop_Core.economy != null) {
-                            Ultimate_Shop_Core.economy.depositPlayer(player, gain);
+                        if (UltimateShopCore.economy != null) {
+                            UltimateShopCore.economy.depositPlayer(player, gain);
                         }
                         player.sendMessage("You sold " + amt + " " + check.getType() + " for $" + gain);
                     } else {
@@ -151,8 +154,8 @@ public class ShopMenuListener implements Listener {
                     if (player.getInventory().containsAtLeast(check, amt)) {
                         player.getInventory().removeItem(check);
                         double gain = shopHolder.getSellPrice() * amt;
-                        if (Ultimate_Shop_Core.economy != null) {
-                            Ultimate_Shop_Core.economy.depositPlayer(player, gain);
+                        if (UltimateShopCore.economy != null) {
+                            UltimateShopCore.economy.depositPlayer(player, gain);
                         }
                         player.sendMessage("You sold " + amt + " " + check.getType() + " for $" + gain);
                     } else {
@@ -262,7 +265,7 @@ public class ShopMenuListener implements Listener {
         }
     }
 
-    private void adjustAmount(Inventory inv, Custom_Inventory holder, ShopTemplate template, int delta) {
+    private void adjustAmount(Inventory inv, CustomInventory holder, ShopTemplate template, int delta) {
         holder.addAmount(delta);
         updateAmountDisplay(inv, template, holder.getDynamicItem(), holder.getAmount());
     }

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/managers/ShopTemplateManager.java
@@ -1,6 +1,6 @@
 package com.hmmbo.ultimate_Shop_Core.shop.managers;
 
-import com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core;
+import com.hmmbo.ultimate_Shop_Core.UltimateShopCore;
 import com.hmmbo.ultimate_Shop_Core.datatypes.Range;
 import com.hmmbo.ultimate_Shop_Core.shop.template.*;
 import com.hmmbo.ultimate_Shop_Core.utils.ItemUtil;
@@ -20,7 +20,7 @@ public class ShopTemplateManager {
     public static final HashMap<String, ShopTemplate> cache = new HashMap<>();
     private static ShopTemplateManager instance;
 
-    public ShopTemplateManager(Ultimate_Shop_Core plugin) {
+    public ShopTemplateManager(UltimateShopCore plugin) {
         this.plugin = plugin;
         this.templateFolder = new File(plugin.getDataFolder(), "templates");
 

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplate.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/shop/template/ShopTemplate.java
@@ -1,6 +1,6 @@
 package com.hmmbo.ultimate_Shop_Core.shop.template;
 
-import com.hmmbo.ultimate_Shop_Core.datatypes.Custom_Inventory;
+import com.hmmbo.ultimate_Shop_Core.datatypes.CustomInventory;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -55,7 +55,7 @@ public class ShopTemplate {
     public Inventory createInventory() {
         int size = rows * 9;
         String title = inventoryName != null ? inventoryName : name;
-        Inventory inventory = Bukkit.createInventory(new Custom_Inventory(this), size, title);
+        Inventory inventory = Bukkit.createInventory(new CustomInventory(this), size, title);
         for (ShopTemplateItemStack templateItem : items) {
             int index = templateItem.getIndex();
             ItemStack stack = templateItem.getItemStack();
@@ -71,7 +71,7 @@ public class ShopTemplate {
     public Inventory createInventory(ItemStack dynamicItem, double buyPrice, double sellPrice) {
         int size = rows * 9;
         String title = inventoryName != null ? inventoryName : name;
-        Inventory inventory = Bukkit.createInventory(new Custom_Inventory(this, dynamicItem, buyPrice, sellPrice), size, title);
+        Inventory inventory = Bukkit.createInventory(new CustomInventory(this, dynamicItem, buyPrice, sellPrice), size, title);
         for (ShopTemplateItemStack templateItem : items) {
             int index = templateItem.getIndex();
             ItemStack stack = templateItem.getItemStack();

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/commands/ShopCommand.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/commands/ShopCommand.java
@@ -1,7 +1,7 @@
 package com.hmmbo.ultimate_Shop_Core.utils.commands;
 
 
-import com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core;
+import com.hmmbo.ultimate_Shop_Core.UltimateShopCore;
 import com.hmmbo.ultimate_Shop_Core.shop.managers.ShopTemplateManager;
 import com.hmmbo.ultimate_Shop_Core.shop.template.ShopTemplate;
 import org.bukkit.command.CommandSender;
@@ -16,7 +16,7 @@ public class ShopCommand {
 
     @Command("shop")
     public void onShopCommand(BukkitCommandActor sender) {
-        String template = Ultimate_Shop_Core.instance.getConfig().getString("shop_template", "default");
+        String template = UltimateShopCore.instance.getConfig().getString("shop_template", "default");
         ShopTemplate shop = ShopTemplateManager.get().getTemplate(template, "shop");
         if (shop != null) {
             sender.asPlayer().openInventory(shop.createInventory());
@@ -28,8 +28,8 @@ public class ShopCommand {
     @Command("shop admin change_template")
     @CommandPermission("usc.admin")
     public void changeTemplate(BukkitCommandActor sender, String name) {
-        Ultimate_Shop_Core.instance.getConfig().set("shop_template", name);
-        Ultimate_Shop_Core.instance.saveConfig();
+        UltimateShopCore.instance.getConfig().set("shop_template", name);
+        UltimateShopCore.instance.saveConfig();
         sender.asPlayer().sendMessage("Shop template changed to " + name + ".");
     }
 

--- a/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/sign/SignInput.java
+++ b/src/main/java/com/hmmbo/ultimate_Shop_Core/utils/sign/SignInput.java
@@ -1,18 +1,15 @@
 package com.hmmbo.ultimate_Shop_Core.utils.sign;
 
-import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLibrary;
-import com.comphenix.protocol.events.PacketAdapter;
-import com.comphenix.protocol.events.PacketEvent;
-import com.comphenix.protocol.events.PacketListener;
-import com.comphenix.protocol.wrappers.BlockPosition;
-import com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core;
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientUpdateSign;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerOpenSignEditor;
+import com.hmmbo.ultimate_Shop_Core.UltimateShopCore;
 import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.util.BlockVector;
 
 import java.util.Map;
 import java.util.UUID;
@@ -21,49 +18,46 @@ import java.util.function.Consumer;
 
 /**
  * Utility for prompting players with a sign editor and retrieving the input.
+ * Uses PacketEvents for minimal packet handling.
  */
 public class SignInput {
     private static final Map<UUID, Consumer<String[]>> callbacks = new ConcurrentHashMap<>();
-    private static PacketListener listener;
+    private static boolean registered = false;
 
     /**
      * Initialise the packet listener. Call this once in plugin onEnable.
      */
     public static void init(Plugin plugin) {
-        if (listener != null) return;
-        listener = new PacketAdapter(plugin, PacketType.Play.Client.UPDATE_SIGN) {
+        if (registered) return;
+
+        PacketEvents.getAPI().getEventManager().registerListener(new PacketListener() {
             @Override
-            public void onPacketReceiving(PacketEvent event) {
-                UUID id = event.getPlayer().getUniqueId();
-                Consumer<String[]> cb = callbacks.remove(id);
+            public void onPacketReceive(PacketReceiveEvent event) {
+                if (event.getPacketType() != PacketType.Play.Client.UPDATE_SIGN) return;
+                Player player = (Player) event.getPlayer();
+                Consumer<String[]> cb = callbacks.remove(player.getUniqueId());
                 if (cb != null) {
-                    String[] lines = event.getPacket().getStringArrays().read(0);
-                    cb.accept(lines);
-                    Location loc = event.getPlayer().getLocation().getBlock().getLocation();
-                    event.getPlayer().sendBlockChange(loc, Material.AIR.createBlockData());
+                    WrapperPlayClientUpdateSign wrapper = new WrapperPlayClientUpdateSign(event);
+                    cb.accept(wrapper.getLines());
                     event.setCancelled(true);
                 }
             }
-        };
-        ProtocolLibrary.getProtocolManager().addPacketListener(listener);
+        });
+        registered = true;
     }
 
     /**
      * Opens a sign editor for the player. The callback is invoked with the entered lines.
      */
     public static void open(Player player, Consumer<String[]> callback) {
-        if (listener == null) {
-            init(Ultimate_Shop_Core.instance);
+        if (!registered) {
+            init(UltimateShopCore.instance);
         }
-        Location loc = player.getLocation();
-        loc = new Location(player.getWorld(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
-        BlockPosition pos = new BlockPosition(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
-        BlockData data = Material.OAK_SIGN.createBlockData();
-        player.sendBlockChange(loc, data);
 
-        var openSign = ProtocolLibrary.getProtocolManager().createPacket(PacketType.Play.Server.OPEN_SIGN_EDITOR);
-        openSign.getBlockPositionModifier().write(0, pos);
-        ProtocolLibrary.getProtocolManager().sendServerPacket(player, openSign);
+        // Use an off-screen position so no sign block is shown to the player.
+        Location loc = new Location(player.getWorld(), 0, 0, 0);
+        WrapperPlayServerOpenSignEditor packet = new WrapperPlayServerOpenSignEditor(loc);
+        PacketEvents.getAPI().getServerManager().sendPacket(player, packet);
 
         callbacks.put(player.getUniqueId(), callback);
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Ultimate_Shop_Core
 version: '1.0-SNAPSHOT'
-main: com.hmmbo.ultimate_Shop_Core.Ultimate_Shop_Core
+main: com.hmmbo.ultimate_Shop_Core.UltimateShopCore
 api-version: '1.21'
-depend: [Vault, ProtocolLib]
+depend: [Vault, PacketEvents]


### PR DESCRIPTION
## Summary
- rename main plugin class and inventory holder to remove underscores
- reorganize listener into `ShopInventoryClickListener`
- migrate sign GUI to PacketEvents with no block placement
- update plugin metadata and dependencies for PacketEvents

## Testing
- `gradle build` *(fails: Could not resolve com.github.retrooper.packetevents)*

------
https://chatgpt.com/codex/tasks/task_e_68637a801498833089cd288984b2fd6e